### PR TITLE
chore: add release of `next` version of sdk on each PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
 jobs:
+  # publish `next` version of SDK on each merged PR to main
   pre-release:
     name: pre-release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,34 @@ on:
     branches:
       - main
 jobs:
+  pre-release:
+    name: pre-release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@buildwithsygma'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - run: yarn sdk:build
+
+      - run: npm publish --workspace=@buildwithsygma/sygma-sdk-core publish --access public --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   maybe-release:
     name: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details
<!--- Provide a general summary of your changes in the Title above -->
Github release action is expanded so it publishes `next` version of the SDK on each closed PR on `main` branch. This way somebody can test features that are not part of any official release.

