### PR TITLE
feat: add helper to create Transfer object

### DIFF
--- a/examples/evm-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-fungible-transfer/src/transfer.ts
@@ -16,7 +16,7 @@ export async function erc20Transfer(): Promise<void> {
   const assetTransfer = new EVMAssetTransfer();
   await assetTransfer.init(provider, Environment.TESTNET);
 
-  const transfer = assetTransfer.buildFungibleTransferObject(
+  const transfer = assetTransfer.createFungibleTransfer(
     await wallet.getAddress(),
     SEPOLIA_CHAIN_ID,
     await wallet.getAddress(), // Sending to the same address on a different chain

--- a/examples/evm-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-fungible-transfer/src/transfer.ts
@@ -1,14 +1,9 @@
-import {
-  EVMAssetTransfer,
-  Environment,
-  Fungible,
-  Transfer,
-} from "@buildwithsygma/sygma-sdk-core";
+import { EVMAssetTransfer, Environment } from "@buildwithsygma/sygma-sdk-core";
 import { Wallet, providers } from "ethers";
 
-export const GOERLI_CHAIN_ID = 5;
-export const SEPOLIA_CHAIN_ID = 11155111;
-export const ERC20_TOKEN_SYMBOL = "ERC20LRTest";
+const SEPOLIA_CHAIN_ID = 11155111;
+const RESOURCE_ID =
+  "0x0000000000000000000000000000000000000000000000000000000000000300";
 
 export async function erc20Transfer(): Promise<void> {
   const provider = new providers.JsonRpcProvider(
@@ -21,33 +16,13 @@ export async function erc20Transfer(): Promise<void> {
   const assetTransfer = new EVMAssetTransfer();
   await assetTransfer.init(provider, Environment.TESTNET);
 
-  const domains = assetTransfer.config.getDomains();
-  const resources = assetTransfer.config.getDomainResources();
-  const erc20Resource = resources.find(
-    (resource) => resource.symbol == ERC20_TOKEN_SYMBOL
+  const transfer = assetTransfer.buildFungibleTransferObject(
+    await wallet.getAddress(),
+    SEPOLIA_CHAIN_ID,
+    await wallet.getAddress(), // Sending to the same address on a different chain
+    RESOURCE_ID,
+    50
   );
-  if (!erc20Resource) {
-    throw new Error("Resource not found");
-  }
-  const goerli = domains.find((domain) => domain.chainId == GOERLI_CHAIN_ID);
-  if (!goerli) {
-    throw new Error("Network goerli not supported");
-  }
-  const sepolia = domains.find((domain) => domain.chainId == SEPOLIA_CHAIN_ID);
-  if (!sepolia) {
-    throw new Error("Network sepolia not supported");
-  }
-  const transfer: Transfer<Fungible> = {
-    sender: await wallet.getAddress(),
-    amount: {
-      // amount in wei
-      amount: "50",
-    },
-    from: goerli,
-    to: sepolia,
-    resource: erc20Resource,
-    recipient: await wallet.getAddress(),
-  };
 
   const fee = await assetTransfer.getFee(transfer);
   const approvals = await assetTransfer.buildApprovals(transfer, fee);
@@ -55,7 +30,7 @@ export async function erc20Transfer(): Promise<void> {
     const response = await wallet.sendTransaction(
       approval as providers.TransactionRequest
     );
-    console.log("Sent approval with hash: " + response.hash);
+    console.log("Sent approval with hash: ", response.hash);
   }
   const transferTx = await assetTransfer.buildTransferTransaction(
     transfer,
@@ -64,7 +39,7 @@ export async function erc20Transfer(): Promise<void> {
   const response = await wallet.sendTransaction(
     transferTx as providers.TransactionRequest
   );
-  console.log("Sent transfer with hash: " + response.hash);
+  console.log("Sent transfer with hash: ", response.hash);
 }
 
 erc20Transfer().finally(() => { });

--- a/examples/evm-to-substrate-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-substrate-fungible-transfer/src/transfer.ts
@@ -18,7 +18,7 @@ export async function erc20Transfer(): Promise<void> {
   await assetTransfer.init(provider, Environment.TESTNET);
 
 
-  const transfer = assetTransfer.buildFungibleTransferObject(
+  const transfer = assetTransfer.createFungibleTransfer(
     await wallet.getAddress(),
     ROCOCO_PHALA_CHAIN_ID,
     DESTINATION_ADDRESS,

--- a/examples/local-fungible-transfer/src/transfer.ts
+++ b/examples/local-fungible-transfer/src/transfer.ts
@@ -80,9 +80,9 @@ export async function fungibleTransferFromEVM(): Promise<void> {
   const transfer = assetTransfer.createFungibleTransfer(
     sender,
     SUBSTRATE_CHAIN_ID,
-    SUBSTRATE_DESTINATION_ADDRESS,
+    account.address,
     RESOURCE_ID,
-    500000000000
+    5000000000000000000
   );
 
   const fee = await assetTransfer.getFee(transfer);

--- a/examples/local-fungible-transfer/src/transfer.ts
+++ b/examples/local-fungible-transfer/src/transfer.ts
@@ -2,19 +2,24 @@ import {
   EVMAssetTransfer,
   Environment,
   Fungible,
-  Transfer, SubstrateAssetTransfer, SubstrateParachain, SubstrateResource,
+  Transfer,
+  SubstrateAssetTransfer,
+  SubstrateParachain,
+  SubstrateResource,
 } from "@buildwithsygma/sygma-sdk-core";
-import {Wallet, providers, ethers, BigNumber} from "ethers";
+import { Wallet, providers, ethers, BigNumber } from "ethers";
 import { Keyring } from "@polkadot/keyring";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 import { ApiPromise, WsProvider } from "@polkadot/api";
-import { ERC20PresetMinterPauser__factory } from "@buildwithsygma/sygma-contracts"
+import { ERC20PresetMinterPauser__factory } from "@buildwithsygma/sygma-contracts";
 import { NonceManager } from "@ethersproject/experimental";
 
 const ERC20_TOKEN_SYMBOL = "ERC20LRTest";
-const SUBSTRATE_DESTINATION_ADDRESS = "5CDQJk6kxvBcjauhrogUc9B8vhbdXhRscp1tGEUmniryF1Vt";
+const SUBSTRATE_DESTINATION_ADDRESS =
+  "5CDQJk6kxvBcjauhrogUc9B8vhbdXhRscp1tGEUmniryF1Vt";
 const EVM_DESTINATION_ADDRESS = "0xD31E89feccCf6f2DE10EaC92ADffF48D802b695C";
-const RESOURCE_ID = "0x0000000000000000000000000000000000000000000000000000000000000300";
+const RESOURCE_ID =
+  "0x0000000000000000000000000000000000000000000000000000000000000300";
 const ERC20_TOKEN_ADDRESS = "0x78E5b9cEC9aEA29071f070C8cC561F692B3511A6";
 
 // Local setup chain IDs
@@ -23,22 +28,20 @@ const EVM2_CHAIN_ID = 1338;
 const SUBSTRATE_CHAIN_ID = 5;
 
 // Local setup RPC URLs
-const EVM1_RPC_URL = "http://127.0.0.1:8545"
-const EVM2_RPC_URL = "http://127.0.0.1:8547"
-const SUBSTRATE_RPC_URL = "ws://127.0.0.1:9944"
+const EVM1_RPC_URL = "http://127.0.0.1:8545";
+const EVM2_RPC_URL = "http://127.0.0.1:8547";
+const SUBSTRATE_RPC_URL = "ws://127.0.0.1:9944";
 
 const ALICE_MNEMONIC =
   "bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice";
-const wsProvider = new WsProvider(
-    SUBSTRATE_RPC_URL
-);
+const wsProvider = new WsProvider(SUBSTRATE_RPC_URL);
 
 const provider = new providers.JsonRpcProvider(EVM1_RPC_URL);
 const w = new Wallet(
-    "cc2c32b154490f09f70c1c8d4b997238448d649e0777495863db231c4ced3616",
-    provider
+  "cc2c32b154490f09f70c1c8d4b997238448d649e0777495863db231c4ced3616",
+  provider
 );
-const wallet = new NonceManager(w)
+const wallet = new NonceManager(w);
 
 export async function fungibleTransferFromEVM(): Promise<void> {
   const keyring = new Keyring({ type: "sr25519" });
@@ -48,55 +51,39 @@ export async function fungibleTransferFromEVM(): Promise<void> {
   const assetTransfer = new EVMAssetTransfer();
   await assetTransfer.init(provider, Environment.LOCAL);
 
-  const domains = assetTransfer.config.getDomains();
-  const resources = assetTransfer.config.getDomainResources();
-
-  const erc20Resource = resources.find(
-    (resource) => resource.symbol == ERC20_TOKEN_SYMBOL
-  );
-  if (!erc20Resource) {
-    throw new Error("Resource not found");
-  }
-  const evm1Network = domains.find((domain) => domain.chainId == EVM1_CHAIN_ID);
-  if (!evm1Network) {
-    throw new Error("Network evm1 not supported");
-  }
-  const substrateNetwork = domains.find(
-    (domain) => domain.chainId == SUBSTRATE_CHAIN_ID
-  );
-  if (!substrateNetwork) {
-    throw new Error("Network substrate not supported");
-  }
-
   const sender = await wallet.getAddress();
   const api = await ApiPromise.create({ provider: wsProvider });
 
   const b = (
-      await api.query.assets.account(2000, account.address)
+    await api.query.assets.account(2000, account.address)
   ).toHuman() as { balance: string };
-  const destinationBalanceBefore = BigNumber.from(b.balance.split(',').join(''))
+  const destinationBalanceBefore = BigNumber.from(
+    b.balance.split(",").join("")
+  ).toString();
 
-  const sourceErc20LR18Contract = new ERC20PresetMinterPauser__factory(
-    wallet as any
-  ).attach(ERC20_TOKEN_ADDRESS);
-  const balanceBefore = await sourceErc20LR18Contract.balanceOf(sender)
+  const sourceErc20LR18Contract = ERC20PresetMinterPauser__factory.connect(
+    ERC20_TOKEN_ADDRESS,
+    wallet
+  );
+
+  const balanceBefore = (
+    await sourceErc20LR18Contract.balanceOf(sender)
+  ).toString();
 
   console.log(`Transferring 5 tokens from evm1 to substrate.`);
   console.log(`Sender: ${sender}`);
   console.log(`Sender token balance on evm1 network before:${balanceBefore}`);
-  console.log(`Sender token balance on substrate network before:${destinationBalanceBefore}`);
+  console.log(
+    `Sender token balance on substrate network before:${destinationBalanceBefore}`
+  );
 
-  const transfer: Transfer<Fungible> = {
-    sender: sender,
-    amount: {
-      // amount in wei
-      amount: "500000000000",
-    },
-    from: evm1Network,
-    to: substrateNetwork,
-    resource: erc20Resource,
-    recipient: EVM_DESTINATION_ADDRESS,
-  };
+  const transfer = assetTransfer.createFungibleTransfer(
+    sender,
+    SUBSTRATE_CHAIN_ID,
+    SUBSTRATE_DESTINATION_ADDRESS,
+    RESOURCE_ID,
+    500000000000
+  );
 
   const fee = await assetTransfer.getFee(transfer);
   const approvals = await assetTransfer.buildApprovals(transfer, fee);
@@ -115,32 +102,36 @@ export async function fungibleTransferFromEVM(): Promise<void> {
   );
   console.log("Sent transfer with hash: " + response.hash);
 
-  console.log("Waiting for relayers to bridge transaction...")
+  console.log("Waiting for relayers to bridge transaction...");
 
   let i = 0;
   let destinationBalanceAfter: BigNumber;
-  for (;;) {
-    await sleep(7000)
+  for (; ;) {
+    await sleep(7000);
     const d = (
-        await api.query.assets.account(2000, account.address)
+      await api.query.assets.account(2000, account.address)
     ).toHuman() as { balance: string };
-    destinationBalanceAfter = BigNumber.from(d.balance.split(',').join(''))
+    destinationBalanceAfter = BigNumber.from(d.balance.split(",").join(""));
     if (!destinationBalanceAfter.eq(destinationBalanceBefore)) {
-      console.log("Transaction successfully bridged.")
-      break
+      console.log("Transaction successfully bridged.");
+      break;
     }
-    i++
-    if (i>5) {
+    i++;
+    if (i > 5) {
       // transaction should have been bridged already
-      console.log("transaction is taking too much time to bridge!")
-      break
+      console.log("transaction is taking too much time to bridge!");
+      break;
     }
   }
 
-  const balanceAfter = await sourceErc20LR18Contract.balanceOf(sender)
+  const balanceAfter = (
+    await sourceErc20LR18Contract.balanceOf(sender)
+  ).toString();
 
   console.log(`Sender token balance on evm1 network after: ${balanceAfter}`);
-  console.log(`Sender token balance on substrate network after: ${destinationBalanceAfter}`);
+  console.log(
+    `Sender token balance on substrate network after: ${destinationBalanceAfter.toString()}`
+  );
 }
 
 export async function fungibleTransferFromSubstrate(): Promise<void> {
@@ -150,56 +141,36 @@ export async function fungibleTransferFromSubstrate(): Promise<void> {
 
   const api = await ApiPromise.create({ provider: wsProvider });
 
-  const destinationErc20LRContract = new ERC20PresetMinterPauser__factory(
-      wallet as any
-  ).attach(ERC20_TOKEN_ADDRESS);
-  const destinationBalanceBefore = await destinationErc20LRContract.balanceOf(EVM_DESTINATION_ADDRESS)
+  const destinationErc20LRContract = ERC20PresetMinterPauser__factory.connect(
+    ERC20_TOKEN_ADDRESS,
+    wallet
+  );
+  const destinationBalanceBefore = await destinationErc20LRContract.balanceOf(
+    EVM_DESTINATION_ADDRESS
+  );
 
   const sourceBalanceBefore = (
     await api.query.assets.account(2000, account.address)
   ).toHuman() as { balance: string };
   console.log(`Transferring 5 tokens from substrate to evm1.`);
   console.log(`Sender (Alice): ${account.address}`);
-  console.log(`Alice token balance on substrate network before:${sourceBalanceBefore.balance}`);
-  console.log(`Alice token balance on evm1 network before:${destinationBalanceBefore}`);
+  console.log(
+    `Alice token balance on substrate network before:${sourceBalanceBefore.balance}`
+  );
+  console.log(
+    `Alice token balance on evm1 network before:${destinationBalanceBefore.toString()}`
+  );
 
   const assetTransfer = new SubstrateAssetTransfer();
-  await assetTransfer.init(
-    api,
-    SubstrateParachain.LOCAL,
-    Environment.LOCAL
-  );
+  await assetTransfer.init(api, Environment.LOCAL);
 
-  const domains = assetTransfer.config.getDomains();
-  const resources = assetTransfer.config.getDomainResources();
-
-  const erc20Resource = resources.find(
-    (resource) => resource.resourceId == RESOURCE_ID
+  const transfer = assetTransfer.createFungibleTransfer(
+    account.address,
+    EVM1_CHAIN_ID,
+    EVM_DESTINATION_ADDRESS,
+    RESOURCE_ID,
+    5
   );
-  if (!erc20Resource) {
-    throw new Error("Resource not found");
-  }
-  const evm1Network = domains.find((domain) => domain.chainId == SUBSTRATE_CHAIN_ID);
-  if (!evm1Network) {
-    throw new Error("Network goerli not supported");
-  }
-  const substrateNetwork = domains.find(
-    (domain) => domain.chainId == EVM1_CHAIN_ID
-  );
-  if (!substrateNetwork) {
-    throw new Error("Network sepolia not supported");
-  }
-
-  const transfer: Transfer<Fungible> = {
-    sender: account.address,
-    amount: {
-      amount: "5",
-    },
-    from: evm1Network,
-    to: substrateNetwork,
-    resource: erc20Resource,
-    recipient: EVM_DESTINATION_ADDRESS,
-  };
 
   const fee = await assetTransfer.getFee(transfer);
 
@@ -219,25 +190,27 @@ export async function fungibleTransferFromSubstrate(): Promise<void> {
       unsub();
     }
 
-    return
+    return;
   });
 
-  console.log("Waiting for relayers to bridge transaction...")
+  console.log("Waiting for relayers to bridge transaction...");
 
   let i = 0;
   let destinationBalanceAfter: BigNumber;
-  for (;;) {
-    await sleep(7000)
-    destinationBalanceAfter = await destinationErc20LRContract.balanceOf(EVM_DESTINATION_ADDRESS)
+  for (; ;) {
+    await sleep(7000);
+    destinationBalanceAfter = await destinationErc20LRContract.balanceOf(
+      EVM_DESTINATION_ADDRESS
+    );
     if (!destinationBalanceAfter.eq(destinationBalanceBefore)) {
-      console.log("Transaction successfully bridged.")
-      break
+      console.log("Transaction successfully bridged.");
+      break;
     }
-    i++
-    if (i>5) {
+    i++;
+    if (i > 5) {
       // transaction should have been bridged already
-      console.log("transaction is taking too much time to bridge!")
-      break
+      console.log("transaction is taking too much time to bridge!");
+      break;
     }
   }
 
@@ -245,13 +218,18 @@ export async function fungibleTransferFromSubstrate(): Promise<void> {
     await api.query.assets.account(2000, account.address)
   ).toHuman() as { balance: string };
 
-  console.log(`Alice token balance on substrate network after: ${balanceAfter.balance}`);
-  console.log(`Alice token balance on evm1 network after: ${destinationBalanceAfter}`);
+  console.log(
+    `Alice token balance on substrate network after: ${balanceAfter.balance}`
+  );
+  console.log(
+    `Alice token balance on evm1 network after: ${destinationBalanceAfter.toString()}`
+  );
 
-  return
+  return;
 }
 
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
 
 // start specific example based on process arg
 switch (process.argv[2]) {
@@ -262,6 +240,5 @@ switch (process.argv[2]) {
     fungibleTransferFromSubstrate().finally(() => { });
     break;
   default:
-    console.log("example not supported")
+    console.log("example not supported");
 }
-

--- a/examples/substrate-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/substrate-to-evm-fungible-transfer/src/transfer.ts
@@ -4,13 +4,9 @@ import { cryptoWaitReady } from "@polkadot/util-crypto";
 
 import {
   Environment,
-  Fungible,
   SubstrateAssetTransfer,
-  SubstrateParachain,
-  Transfer,
 } from "@buildwithsygma/sygma-sdk-core";
 
-const ROCOCO_CHAIN_ID = 5231;
 const GOERLI_CHAIN_ID = 5;
 const RESOURCE_ID =
   "0x0000000000000000000000000000000000000000000000000000000000001000";
@@ -34,40 +30,15 @@ const substrateTransfer = async (): Promise<void> => {
 
   const assetTransfer = new SubstrateAssetTransfer();
 
-  await assetTransfer.init(
-    api,
-    SubstrateParachain.ROCOCO_PHALA,
-    Environment.TESTNET
-  );
+  await assetTransfer.init(api, Environment.TESTNET);
 
-  const domains = assetTransfer.config.getDomains();
-  const resources = assetTransfer.config.getDomainResources();
-  const selectedResource = resources.find(
-    (resource) => resource.resourceId == RESOURCE_ID
+  const transfer = assetTransfer.buildFungibleTransferObject(
+    account.address,
+    GOERLI_CHAIN_ID,
+    recipient,
+    RESOURCE_ID,
+    50
   );
-  if (!selectedResource) {
-    throw new Error("Resource not found");
-  }
-  const rococo = domains.find((domain) => domain.chainId == ROCOCO_CHAIN_ID);
-  if (!rococo) {
-    throw new Error("Network Rococo-Phala not supported");
-  }
-  const goerli = domains.find((domain) => domain.chainId == GOERLI_CHAIN_ID);
-  if (!goerli) {
-    throw new Error("Network sepolia not supported");
-  }
-
-  const transfer: Transfer<Fungible> = {
-    sender: account.address,
-    amount: {
-      // amount in wei
-      amount: "50",
-    },
-    from: rococo,
-    to: goerli,
-    resource: selectedResource,
-    recipient: recipient,
-  };
 
   const fee = await assetTransfer.getFee(transfer);
 
@@ -91,4 +62,4 @@ const substrateTransfer = async (): Promise<void> => {
 
 substrateTransfer()
   .catch((e) => console.log(e))
-  .finally(() => {});
+  .finally(() => { });

--- a/examples/substrate-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/substrate-to-evm-fungible-transfer/src/transfer.ts
@@ -32,7 +32,7 @@ const substrateTransfer = async (): Promise<void> => {
 
   await assetTransfer.init(api, Environment.TESTNET);
 
-  const transfer = assetTransfer.buildFungibleTransferObject(
+  const transfer = assetTransfer.createFungibleTransfer(
     account.address,
     GOERLI_CHAIN_ID,
     recipient,

--- a/packages/sdk/src/chains/BaseAssetTransfer.ts
+++ b/packages/sdk/src/chains/BaseAssetTransfer.ts
@@ -4,7 +4,7 @@ import { Config } from '../config';
 export abstract class BaseAssetTransfer {
   public config!: Config;
 
-  public buildFungibleTransferObject(
+  public createFungibleTransfer(
     sourceAddress: string,
     destinationChainId: number,
     destinationAddress: string,

--- a/packages/sdk/src/chains/BaseAssetTransfer.ts
+++ b/packages/sdk/src/chains/BaseAssetTransfer.ts
@@ -1,8 +1,9 @@
-import { Fungible, Transfer } from '../types';
+import { Environment, Fungible, Transfer } from '../types';
 import { Config } from '../config';
 
 export abstract class BaseAssetTransfer {
   public config!: Config;
+  public environment!: Environment;
 
   public createFungibleTransfer(
     sourceAddress: string,

--- a/packages/sdk/src/chains/BaseAssetTransfer.ts
+++ b/packages/sdk/src/chains/BaseAssetTransfer.ts
@@ -1,0 +1,42 @@
+import { Fungible, Transfer } from '../types';
+import { Config } from '../config';
+
+export abstract class BaseAssetTransfer {
+  public config!: Config;
+
+  public buildFungibleTransferObject(
+    sourceAddress: string,
+    destinationChainId: number,
+    destinationAddress: string,
+    resourceId: string,
+    amount: number,
+  ): Transfer<Fungible> {
+    const domains = this.config.getDomains();
+    const sourceDomain = domains.find(domain => domain.chainId == this.config.chainId);
+    if (!sourceDomain) {
+      throw new Error('Source domain not supported');
+    }
+    const destinationDomain = domains.find(domain => domain.chainId == destinationChainId);
+    if (!destinationDomain) {
+      throw new Error('Destination domain not supported');
+    }
+    const resources = this.config.getDomainResources();
+    const selectedResource = resources.find(resource => resource.resourceId == resourceId);
+    if (!selectedResource) {
+      throw new Error('Resource not found');
+    }
+
+    const transfer: Transfer<Fungible> = {
+      sender: sourceAddress,
+      amount: {
+        amount: amount.toString(),
+      },
+      from: sourceDomain,
+      to: destinationDomain,
+      resource: selectedResource,
+      recipient: destinationAddress,
+    };
+
+    return transfer;
+  }
+}

--- a/packages/sdk/src/chains/EVM/assetTransfer.ts
+++ b/packages/sdk/src/chains/EVM/assetTransfer.ts
@@ -73,7 +73,7 @@ export class EVMAssetTransfer extends BaseAssetTransfer {
 
   public async init(
     provider: providers.BaseProvider,
-    environment: Environment = Environment.LOCAL,
+    environment: Environment = Environment.MAINNET,
   ): Promise<void> {
     this.provider = provider;
     const network = await this.provider.getNetwork();

--- a/packages/sdk/src/chains/EVM/assetTransfer.ts
+++ b/packages/sdk/src/chains/EVM/assetTransfer.ts
@@ -69,7 +69,6 @@ import {
  */
 export class EVMAssetTransfer extends BaseAssetTransfer {
   private provider!: providers.BaseProvider;
-  private environment!: Environment;
 
   public async init(
     provider: providers.BaseProvider,

--- a/packages/sdk/src/chains/EVM/assetTransfer.ts
+++ b/packages/sdk/src/chains/EVM/assetTransfer.ts
@@ -22,6 +22,7 @@ import {
 } from '../../types';
 import { Config } from '../..';
 import { getFeeOracleBaseURL } from '../../utils';
+import { BaseAssetTransfer } from '../BaseAssetTransfer';
 import {
   EvmFee,
   approve,
@@ -66,16 +67,17 @@ import {
  * await wallet.sendTransaction(trasnferTx);
  *
  */
-export class EVMAssetTransfer {
+export class EVMAssetTransfer extends BaseAssetTransfer {
   private provider!: providers.BaseProvider;
   private environment!: Environment;
 
-  public config!: Config;
-
-  public async init(provider: providers.BaseProvider, environment?: Environment): Promise<void> {
+  public async init(
+    provider: providers.BaseProvider,
+    environment: Environment = Environment.LOCAL,
+  ): Promise<void> {
     this.provider = provider;
     const network = await this.provider.getNetwork();
-    this.environment = environment ? environment : Environment.MAINNET;
+    this.environment = environment;
     this.config = new Config();
     await this.config.init(network.chainId, environment);
   }

--- a/packages/sdk/src/chains/Substrate/assetTransfer.ts
+++ b/packages/sdk/src/chains/Substrate/assetTransfer.ts
@@ -94,7 +94,8 @@ export class SubstrateAssetTransfer extends BaseAssetTransfer {
       }
       default:
         throw new Error(
-          `Resource type ${transfer.resource.type
+          `Resource type ${
+            transfer.resource.type
           } with ${fee.fee.toString()} not supported by asset transfer`,
         );
     }

--- a/packages/sdk/src/chains/Substrate/assetTransfer.ts
+++ b/packages/sdk/src/chains/Substrate/assetTransfer.ts
@@ -97,7 +97,8 @@ export class SubstrateAssetTransfer extends BaseAssetTransfer {
       }
       default:
         throw new Error(
-          `Resource type ${transfer.resource.type
+          `Resource type ${
+            transfer.resource.type
           } with ${fee.fee.toString()} not supported by asset transfer`,
         );
     }

--- a/packages/sdk/src/chains/Substrate/assetTransfer.ts
+++ b/packages/sdk/src/chains/Substrate/assetTransfer.ts
@@ -1,15 +1,16 @@
 import { ApiPromise, SubmittableResult } from '@polkadot/api';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { U256 } from '@polkadot/types';
 import {
   Environment,
   Fungible,
   ResourceType,
-  SubstrateParachain,
   SubstrateResource,
   Transfer,
   TransferType,
 } from '../../types';
 import { Config } from '../..';
+import { BaseAssetTransfer } from '../BaseAssetTransfer';
 import { SubstrateFee, deposit, getBasicFee } from '.';
 
 /**
@@ -40,19 +41,18 @@ import { SubstrateFee, deposit, getBasicFee } from '.';
  *
  * <sign and send transfer>
  */
-export class SubstrateAssetTransfer {
+export class SubstrateAssetTransfer extends BaseAssetTransfer {
   private apiPromise!: ApiPromise;
-
-  public config!: Config;
 
   public async init(
     apiPromise: ApiPromise,
-    parachainId: SubstrateParachain,
     environment: Environment = Environment.LOCAL,
   ): Promise<void> {
     this.apiPromise = apiPromise;
+    const parachainId = apiPromise.consts.sygmaBridge.eip712ChainID as U256;
     this.config = new Config();
-    await this.config.init(parachainId.valueOf(), environment);
+    // This is probably not too safe and might overflow
+    await this.config.init(parachainId.toNumber(), environment);
   }
 
   /**
@@ -94,8 +94,7 @@ export class SubstrateAssetTransfer {
       }
       default:
         throw new Error(
-          `Resource type ${
-            transfer.resource.type
+          `Resource type ${transfer.resource.type
           } with ${fee.fee.toString()} not supported by asset transfer`,
         );
     }

--- a/packages/sdk/src/chains/Substrate/assetTransfer.ts
+++ b/packages/sdk/src/chains/Substrate/assetTransfer.ts
@@ -43,8 +43,6 @@ import { SubstrateFee, deposit, getBasicFee } from '.';
  */
 export class SubstrateAssetTransfer extends BaseAssetTransfer {
   private apiPromise!: ApiPromise;
-  private environment!: Environment;
-  public config!: Config;
 
   public async init(
     apiPromise: ApiPromise,
@@ -52,6 +50,8 @@ export class SubstrateAssetTransfer extends BaseAssetTransfer {
   ): Promise<void> {
     this.apiPromise = apiPromise;
     const parachainId = apiPromise.consts.sygmaBridge.eip712ChainID as U256;
+    this.environment = environment;
+
     this.config = new Config();
     // This is probably not too safe and might overflow
     await this.config.init(parachainId.toNumber(), environment);
@@ -97,8 +97,7 @@ export class SubstrateAssetTransfer extends BaseAssetTransfer {
       }
       default:
         throw new Error(
-          `Resource type ${
-            transfer.resource.type
+          `Resource type ${transfer.resource.type
           } with ${fee.fee.toString()} not supported by asset transfer`,
         );
     }

--- a/packages/sdk/src/chains/Substrate/assetTransfer.ts
+++ b/packages/sdk/src/chains/Substrate/assetTransfer.ts
@@ -46,7 +46,7 @@ export class SubstrateAssetTransfer extends BaseAssetTransfer {
 
   public async init(
     apiPromise: ApiPromise,
-    environment: Environment = Environment.LOCAL,
+    environment: Environment = Environment.MAINNET,
   ): Promise<void> {
     this.apiPromise = apiPromise;
     const parachainId = apiPromise.consts.sygmaBridge.eip712ChainID as U256;

--- a/packages/sdk/src/chains/Substrate/utils/depositFns.ts
+++ b/packages/sdk/src/chains/Substrate/utils/depositFns.ts
@@ -172,7 +172,7 @@ export const createDestIdMultilocationData = (
         parents: 0,
         interior: {
           x2: [
-            { generalKey: [20, address.padEnd(66, '0')] },
+            { generalKey: [(address.length - 2) / 2, address.padEnd(66, '0')] },
             { generalKey: [1, numberToHex(Number(domainId)).padEnd(66, '0')] },
           ],
         },

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -11,33 +11,32 @@ import {
 import { ConfigUrl } from './index.js';
 
 export class Config {
-  public environment!: RawConfig;
   public chainId!: number;
+  public environment!: RawConfig;
 
-  public async init(chainId: number, environment?: Environment): Promise<void> {
+  public async init(chainId: number, environment: Environment): Promise<void> {
     this.chainId = chainId;
-
     if (environment === Environment.LOCAL) {
       this.environment = localConfig;
       return;
     }
 
-    let network;
+    let configUrl;
     switch (environment) {
       case Environment.DEVNET: {
-        network = ConfigUrl.DEVNET;
+        configUrl = ConfigUrl.DEVNET;
         break;
       }
       case Environment.TESTNET: {
-        network = ConfigUrl.TESTNET;
+        configUrl = ConfigUrl.TESTNET;
         break;
       }
       default:
-        network = ConfigUrl.MAINNET;
+        configUrl = ConfigUrl.MAINNET;
     }
 
     try {
-      const response = await axios.get(network);
+      const response = await axios.get(configUrl);
       this.environment = response.data as unknown as RawConfig;
     } catch (err) {
       if (err instanceof Error) {

--- a/packages/sdk/test/chains/EVM/assetTransfer.test.ts
+++ b/packages/sdk/test/chains/EVM/assetTransfer.test.ts
@@ -1,6 +1,6 @@
-import axios from "axios";
-import { BigNumber, providers } from "ethers";
-import MockAdapter from "axios-mock-adapter";
+import axios from 'axios';
+import { BigNumber, providers } from 'ethers';
+import MockAdapter from 'axios-mock-adapter';
 
 import {
   Transfer,
@@ -9,20 +9,20 @@ import {
   Environment,
   NonFungible,
   Fungible,
-} from "../../../src/types";
-import { testingConfigData } from "../../constants";
-import { ConfigUrl } from "../../../src/constants";
-import { EVMAssetTransfer } from "../../../src/chains/EVM";
-import * as EVM from "../../../src/chains/EVM";
-import { DEVNET_FEE_ORACLE_BASE_URL } from "../../../src/utils";
+} from '../../../src/types';
+import { testingConfigData } from '../../constants';
+import { ConfigUrl } from '../../../src/constants';
+import { EVMAssetTransfer } from '../../../src/chains/EVM';
+import * as EVM from '../../../src/chains/EVM';
+import { DEVNET_FEE_ORACLE_BASE_URL } from '../../../src/utils';
 
 const feeHandlerAddressFunction = jest.fn();
 const resourceHandlerFunction = jest.fn();
 jest.mock(
-  "@buildwithsygma/sygma-contracts",
+  '@buildwithsygma/sygma-contracts',
   () =>
     ({
-      ...(jest.requireActual("@buildwithsygma/sygma-contracts") as {}),
+      ...jest.requireActual('@buildwithsygma/sygma-contracts'),
       FeeHandlerRouter__factory: {
         connect: () => {
           return {
@@ -47,7 +47,7 @@ jest.mock(
           };
         },
       },
-    } as unknown)
+    } as unknown),
 );
 const axiosMock = new MockAdapter(axios);
 const mockProvider: Partial<providers.Provider> = {
@@ -56,76 +56,70 @@ const mockProvider: Partial<providers.Provider> = {
     chainId: 11155111,
   }),
 };
-const calculateBasicFeeMock = jest
-  .spyOn(EVM, "calculateBasicfee")
-  .mockResolvedValue({
-    fee: BigNumber.from("100"),
-    type: FeeHandlerType.BASIC,
-    handlerAddress: "0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622",
-  });
-const calculateDynamicFeeMock = jest
-  .spyOn(EVM, "calculateDynamicFee")
-  .mockResolvedValue({
-    fee: BigNumber.from("100"),
-    type: FeeHandlerType.DYNAMIC,
-    handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
-  });
-const isApprovedMock = jest.spyOn(EVM, "isApproved");
-const getAllowanceMock = jest.spyOn(EVM, "getERC20Allowance");
-const approveMock = jest.spyOn(EVM, "approve");
-const erc20TransferMock = jest.spyOn(EVM, "erc20Transfer");
-const erc721TransferMock = jest.spyOn(EVM, "erc721Transfer");
+const calculateBasicFeeMock = jest.spyOn(EVM, 'calculateBasicfee').mockResolvedValue({
+  fee: BigNumber.from('100'),
+  type: FeeHandlerType.BASIC,
+  handlerAddress: '0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622',
+});
+const calculateDynamicFeeMock = jest.spyOn(EVM, 'calculateDynamicFee').mockResolvedValue({
+  fee: BigNumber.from('100'),
+  type: FeeHandlerType.DYNAMIC,
+  handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
+});
+const isApprovedMock = jest.spyOn(EVM, 'isApproved');
+const getAllowanceMock = jest.spyOn(EVM, 'getERC20Allowance');
+const approveMock = jest.spyOn(EVM, 'approve');
+const erc20TransferMock = jest.spyOn(EVM, 'erc20Transfer');
+const erc721TransferMock = jest.spyOn(EVM, 'erc721Transfer');
 
-describe("EVM asset transfer", () => {
+describe('EVM asset transfer', () => {
   let assetTransfer: EVMAssetTransfer;
   const transfer: Transfer<Fungible> = {
     to: {
-      name: "Sepolia",
-      chainId: 11155111, 
+      name: 'Sepolia',
+      chainId: 11155111,
       id: 3,
     },
     from: {
-      name: "Mumbai",
+      name: 'Mumbai',
       chainId: 80001,
       id: 2,
     },
     resource: {
-      resourceId:
-        "0x0000000000000000000000000000000000000000000000000000000000000300",
-      address: "0x3690601896C289be2d894c3d1213405310D0a25C",
+      resourceId: '0x0000000000000000000000000000000000000000000000000000000000000300',
+      address: '0x3690601896C289be2d894c3d1213405310D0a25C',
       type: ResourceType.FUNGIBLE,
-      symbol: "LR",
+      symbol: 'LR',
       decimals: 18,
     },
-    sender: "0x3690601896C289be2d894c3d1213405310D0a25C",
-    recipient: "0x557abEc0cb31Aa925577441d54C090987c2ED818",
+    sender: '0x3690601896C289be2d894c3d1213405310D0a25C',
+    recipient: '0x557abEc0cb31Aa925577441d54C090987c2ED818',
     amount: {
-      amount: "200",
+      amount: '200',
     },
   };
   const nonFungibleTransfer: Transfer<NonFungible> = {
     to: {
-      name: "Sepolia",
-      chainId: 11155111, 
+      name: 'Sepolia',
+      chainId: 11155111,
       id: 3,
     },
     from: {
-      name: "Mumbai",
+      name: 'Mumbai',
       chainId: 80001,
       id: 2,
     },
     resource: {
-      resourceId:
-        "0x0000000000000000000000000000000000000000000000000000000000000300",
-      address: "0x3690601896C289be2d894c3d1213405310D0a25C",
+      resourceId: '0x0000000000000000000000000000000000000000000000000000000000000300',
+      address: '0x3690601896C289be2d894c3d1213405310D0a25C',
       type: ResourceType.NON_FUNGIBLE,
-      symbol: "LR",
+      symbol: 'LR',
       decimals: 18,
     },
-    sender: "0x3690601896C289be2d894c3d1213405310D0a25C",
-    recipient: "0x557abEc0cb31Aa925577441d54C090987c2ED818",
+    sender: '0x3690601896C289be2d894c3d1213405310D0a25C',
+    recipient: '0x557abEc0cb31Aa925577441d54C090987c2ED818',
     amount: {
-      id: "id",
+      id: 'id',
     },
   };
 
@@ -139,22 +133,20 @@ describe("EVM asset transfer", () => {
     jest.clearAllMocks();
   });
 
-  describe("getFee", () => {
-    it("Should successfully get basic fee", async function () {
-      feeHandlerAddressFunction.mockResolvedValue(
-        "0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622"
-      );
+  describe('getFee', () => {
+    it('Should successfully get basic fee', async function () {
+      feeHandlerAddressFunction.mockResolvedValue('0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622');
 
       const fee = await assetTransfer.getFee(transfer);
 
       expect(fee).toEqual({
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.BASIC,
-        handlerAddress: "0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622",
+        handlerAddress: '0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622',
       });
       expect(calculateBasicFeeMock).toBeCalled();
       expect(calculateBasicFeeMock).toBeCalledWith({
-        basicFeeHandlerAddress: "0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622",
+        basicFeeHandlerAddress: '0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622',
         toDomainID: transfer.to.id,
         fromDomainID: transfer.from.id,
         provider: mockProvider,
@@ -163,142 +155,124 @@ describe("EVM asset transfer", () => {
       });
     });
 
-    it("Should successfully get dynamic fee", async function () {
-      feeHandlerAddressFunction.mockResolvedValue(
-        "0xe495c86962DcA7208ECcF2020A273395AcE8da3e"
-      );
+    it('Should successfully get dynamic fee', async function () {
+      feeHandlerAddressFunction.mockResolvedValue('0xe495c86962DcA7208ECcF2020A273395AcE8da3e');
 
       const fee = await assetTransfer.getFee(transfer);
 
       expect(fee).toEqual({
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.DYNAMIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       });
       expect(calculateDynamicFeeMock).toBeCalled();
       expect(calculateDynamicFeeMock).toBeCalledWith({
-        feeHandlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        feeHandlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
         feeOracleBaseUrl: DEVNET_FEE_ORACLE_BASE_URL,
         toDomainID: transfer.to.id,
         fromDomainID: transfer.from.id,
         provider: mockProvider,
         resourceID: transfer.resource.resourceId,
         sender: transfer.sender,
-        tokenAmount: "200",
+        tokenAmount: '200',
         recipientAddress: transfer.recipient,
       });
     });
 
-    it("Should throw error for unsupported fee handler", async function () {
-      feeHandlerAddressFunction.mockResolvedValue("0xunsupported");
+    it('Should throw error for unsupported fee handler', async function () {
+      feeHandlerAddressFunction.mockResolvedValue('0xunsupported');
 
       try {
         await assetTransfer.getFee(transfer);
-        fail("error not thrown");
+        fail('error not thrown');
       } catch (e) {
-        expect(e).toEqual(new Error("Unsupported fee handler type"));
+        expect(e).toEqual(new Error('Unsupported fee handler type'));
       }
     });
   });
 
-  describe("buildApprovals", function () {
-    it("Should return empty array if ERC20 token already approved", async function () {
-      resourceHandlerFunction.mockResolvedValue(
-        "0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB"
-      );
-      getAllowanceMock.mockResolvedValue(BigNumber.from("250"));
+  describe('buildApprovals', function () {
+    it('Should return empty array if ERC20 token already approved', async function () {
+      resourceHandlerFunction.mockResolvedValue('0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB');
+      getAllowanceMock.mockResolvedValue(BigNumber.from('250'));
 
       const fee = {
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.DYNAMIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
       const approvals = await assetTransfer.buildApprovals(transfer, fee);
 
       expect(approvals).toEqual([]);
     });
 
-    it("Should return approval tx if ERC20 token not approved and basic fee used", async function () {
-      resourceHandlerFunction.mockResolvedValue(
-        "0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB"
-      );
-      getAllowanceMock.mockResolvedValue(BigNumber.from("150"));
+    it('Should return approval tx if ERC20 token not approved and basic fee used', async function () {
+      resourceHandlerFunction.mockResolvedValue('0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB');
+      getAllowanceMock.mockResolvedValue(BigNumber.from('150'));
       approveMock.mockResolvedValue({});
 
       const fee = {
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.DYNAMIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
       const approvals = await assetTransfer.buildApprovals(transfer, fee);
 
       expect(approvals.length).toBe(1);
     });
 
-    it("Should return 2 approval txs if ERC20 token not approved and dynamic fee used", async function () {
-      resourceHandlerFunction.mockResolvedValue(
-        "0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB"
-      );
-      getAllowanceMock.mockResolvedValue(BigNumber.from("0"));
+    it('Should return 2 approval txs if ERC20 token not approved and dynamic fee used', async function () {
+      resourceHandlerFunction.mockResolvedValue('0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB');
+      getAllowanceMock.mockResolvedValue(BigNumber.from('0'));
       approveMock.mockResolvedValue({});
 
       const fee = {
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.DYNAMIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
       const approvals = await assetTransfer.buildApprovals(transfer, fee);
 
       expect(approvals.length).toBe(2);
     });
 
-    it("Should return empty array if ERC721 token already approved", async function () {
-      resourceHandlerFunction.mockResolvedValue(
-        "0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB"
-      );
+    it('Should return empty array if ERC721 token already approved', async function () {
+      resourceHandlerFunction.mockResolvedValue('0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB');
       isApprovedMock.mockResolvedValue(true);
 
       const fee = {
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.BASIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
-      const approvals = await assetTransfer.buildApprovals(
-        nonFungibleTransfer,
-        fee
-      );
+      const approvals = await assetTransfer.buildApprovals(nonFungibleTransfer, fee);
 
       expect(approvals.length).toBe(0);
     });
 
-    it("Should return approval tx if ERC721 token not approved", async function () {
-      resourceHandlerFunction.mockResolvedValue(
-        "0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB"
-      );
+    it('Should return approval tx if ERC721 token not approved', async function () {
+      resourceHandlerFunction.mockResolvedValue('0x03896BaeA3A8CD98E46C576AF6Ceaffb69a51AFB');
       isApprovedMock.mockResolvedValue(false);
 
       const fee = {
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.BASIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
-      const approvals = await assetTransfer.buildApprovals(
-        nonFungibleTransfer,
-        fee
-      );
+      const approvals = await assetTransfer.buildApprovals(nonFungibleTransfer, fee);
 
       expect(approvals.length).toBe(1);
     });
   });
 
-  describe("buildTransferTransaction", () => {
-    it("Should build erc20 transfer tx if resource type FUNGIBLE", async function () {
+  describe('buildTransferTransaction', () => {
+    it('Should build erc20 transfer tx if resource type FUNGIBLE', async function () {
       erc20TransferMock.mockResolvedValue({});
 
       const fee = {
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.BASIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
       const tx = await assetTransfer.buildTransferTransaction(transfer, fee);
 
@@ -306,18 +280,15 @@ describe("EVM asset transfer", () => {
       expect(erc20TransferMock).toBeCalled();
     });
 
-    it("Should build erc721 transfer tx if resource type NONFUNGIBLE", async function () {
+    it('Should build erc721 transfer tx if resource type NONFUNGIBLE', async function () {
       erc721TransferMock.mockResolvedValue({});
 
       const fee = {
-        fee: BigNumber.from("100"),
+        fee: BigNumber.from('100'),
         type: FeeHandlerType.BASIC,
-        handlerAddress: "0xe495c86962DcA7208ECcF2020A273395AcE8da3e",
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
-      const tx = await assetTransfer.buildTransferTransaction(
-        nonFungibleTransfer,
-        fee
-      );
+      const tx = await assetTransfer.buildTransferTransaction(nonFungibleTransfer, fee);
 
       expect(tx).toBeDefined();
       expect(erc721TransferMock).toBeCalled();

--- a/packages/sdk/test/chains/Substrate/assetTransfer.test.ts
+++ b/packages/sdk/test/chains/Substrate/assetTransfer.test.ts
@@ -1,38 +1,37 @@
 import axios from 'axios';
-import { BigNumber, providers } from 'ethers';
+import { BigNumber } from 'ethers';
 import MockAdapter from 'axios-mock-adapter';
 
 import { ApiPromise } from '@polkadot/api';
+import { BN } from '@polkadot/util';
 import { FeeHandlerType, Environment } from '../../../src/types';
 import { testingConfigData } from '../../constants';
 import { ConfigUrl } from '../../../src/constants';
 import { SubstrateAssetTransfer } from '../../../src/chains/Substrate';
 import * as Substrate from '../../../src/chains/Substrate';
 
-const feeHandlerAddressFunction = jest.fn();
-
 const axiosMock = new MockAdapter(axios);
-const mockProvider: Partial<providers.Provider> = {
-  getFeeData: jest.fn().mockResolvedValue({ gasPrice: BigNumber.from(100) }),
-  getNetwork: jest.fn().mockResolvedValue({
-    chainId: 11155111,
-  }),
-};
 
 const mockApiPromise = {
-  api: {
-    consts: {
-      sygmaBridge: {
-        eip712ChainID: 5,
-      },
-    },
-    query: {
-      sygmaBasicFeeHandler: {
-        assetFees: jest.fn(),
-      },
+  consts: {
+    sygmaBridge: {
+      eip712ChainID: new BN(400),
     },
   },
-} as Partial<ApiPromise>;
+  query: {
+    sygmaBasicFeeHandler: {
+      assetFees: jest.fn(),
+    },
+  },
+  registry: {
+    chainDecimals: [new BN(10)],
+  },
+  tx: {
+    sygmaBridge: {
+      deposit: jest.fn().mockResolvedValue({ a: 'b' }),
+    },
+  },
+} as unknown as Partial<ApiPromise>;
 
 const calculateBasicFeeMock = jest.spyOn(Substrate, 'getBasicFee').mockResolvedValue({
   fee: BigNumber.from('100'),
@@ -61,18 +60,18 @@ describe('Substrate asset transfer', () => {
           id: 3,
         },
         from: {
-          name: 'Mumbai',
-          chainId: 80001,
-          id: 2,
+          name: 'rococo-phala',
+          chainId: 400,
+          id: 5,
         },
         resource: {
-          resourceId: '0x0000000000000000000000000000000000000000000000000000000000000300',
-          address: '0x3690601896C289be2d894c3d1213405310D0a25C',
+          resourceId: '0x0000000000000000000000000000000000000000000000000000000000001000',
+          address: '',
           type: 'fungible',
-          symbol: 'LR',
+          symbol: 'PHA',
           decimals: 18,
         },
-        sender: '0x3690601896C289be2d894c3d1213405310D0a25C',
+        sender: '5FNHV5TZAQ1AofSPbP7agn5UesXSYDX9JycUSCJpNuwgoYTS',
         recipient: '0x557abEc0cb31Aa925577441d54C090987c2ED818',
         amount: {
           amount: '200',
@@ -80,10 +79,10 @@ describe('Substrate asset transfer', () => {
       };
 
       const actualVal = assetTransfer.createFungibleTransfer(
-        '0x3690601896C289be2d894c3d1213405310D0a25C',
+        '5FNHV5TZAQ1AofSPbP7agn5UesXSYDX9JycUSCJpNuwgoYTS',
         11155111,
         '0x557abEc0cb31Aa925577441d54C090987c2ED818',
-        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        '0x0000000000000000000000000000000000000000000000000000000000001000',
         200,
       );
 
@@ -93,89 +92,38 @@ describe('Substrate asset transfer', () => {
 
   describe('getFee', () => {
     it('Should successfully get basic fee', async function () {
-      feeHandlerAddressFunction.mockResolvedValue('0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622');
-
       const transfer = assetTransfer.createFungibleTransfer(
         '0x3690601896C289be2d894c3d1213405310D0a25C',
         11155111,
         '0x557abEc0cb31Aa925577441d54C090987c2ED818',
-        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        '0x0000000000000000000000000000000000000000000000000000000000001000',
         200,
       );
 
       const fee = await assetTransfer.getFee(transfer);
 
       expect(fee).toEqual({
-        fee: BigNumber.from('100'),
+        fee: BigNumber.from(100),
         type: FeeHandlerType.BASIC,
-        handlerAddress: '0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622',
       });
+
       expect(calculateBasicFeeMock).toBeCalled();
-      expect(calculateBasicFeeMock).toBeCalledWith({
-        basicFeeHandlerAddress: '0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622',
-        toDomainID: transfer.to.id,
-        fromDomainID: transfer.from.id,
-        provider: mockProvider,
-        resourceID: transfer.resource.resourceId,
-        sender: transfer.sender,
-      });
-    });
-
-    it('Should throw error for unsupported fee handler', async function () {
-      feeHandlerAddressFunction.mockResolvedValue('0xunsupported');
-
-      const transfer = assetTransfer.createFungibleTransfer(
-        '0x3690601896C289be2d894c3d1213405310D0a25C',
-        11155111,
-        '0x557abEc0cb31Aa925577441d54C090987c2ED818',
-        '0x0000000000000000000000000000000000000000000000000000000000000300',
-        200,
-      );
-
-      try {
-        await assetTransfer.getFee(transfer);
-        fail('error not thrown');
-      } catch (e) {
-        expect(e).toEqual(new Error('Unsupported fee handler type'));
-      }
     });
   });
 
   describe('buildTransferTransaction', () => {
     it('Should build fungible transfer tx if resource type FUNGIBLE', function () {
       const transfer = assetTransfer.createFungibleTransfer(
-        '0x3690601896C289be2d894c3d1213405310D0a25C',
+        '5FNHV5TZAQ1AofSPbP7agn5UesXSYDX9JycUSCJpNuwgoYTS',
         11155111,
         '0x557abEc0cb31Aa925577441d54C090987c2ED818',
-        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        '0x0000000000000000000000000000000000000000000000000000000000001000',
         200,
       );
 
       const fee = {
         fee: BigNumber.from('100'),
         type: FeeHandlerType.BASIC,
-        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
-      };
-      const tx = assetTransfer.buildTransferTransaction(transfer, fee);
-
-      expect(tx).toBeDefined();
-    });
-  });
-
-  describe('buildTransferTransaction', () => {
-    it('Should build erc20 transfer tx if resource type FUNGIBLE', function () {
-      const transfer = assetTransfer.createFungibleTransfer(
-        '0x3690601896C289be2d894c3d1213405310D0a25C',
-        11155111,
-        '0x557abEc0cb31Aa925577441d54C090987c2ED818',
-        '0x0000000000000000000000000000000000000000000000000000000000000300',
-        200,
-      );
-
-      const fee = {
-        fee: BigNumber.from('100'),
-        type: FeeHandlerType.BASIC,
-        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
       };
       const tx = assetTransfer.buildTransferTransaction(transfer, fee);
 

--- a/packages/sdk/test/chains/Substrate/assetTransfer.test.ts
+++ b/packages/sdk/test/chains/Substrate/assetTransfer.test.ts
@@ -1,0 +1,185 @@
+import axios from 'axios';
+import { BigNumber, providers } from 'ethers';
+import MockAdapter from 'axios-mock-adapter';
+
+import { ApiPromise } from '@polkadot/api';
+import { FeeHandlerType, Environment } from '../../../src/types';
+import { testingConfigData } from '../../constants';
+import { ConfigUrl } from '../../../src/constants';
+import { SubstrateAssetTransfer } from '../../../src/chains/Substrate';
+import * as Substrate from '../../../src/chains/Substrate';
+
+const feeHandlerAddressFunction = jest.fn();
+
+const axiosMock = new MockAdapter(axios);
+const mockProvider: Partial<providers.Provider> = {
+  getFeeData: jest.fn().mockResolvedValue({ gasPrice: BigNumber.from(100) }),
+  getNetwork: jest.fn().mockResolvedValue({
+    chainId: 11155111,
+  }),
+};
+
+const mockApiPromise = {
+  api: {
+    consts: {
+      sygmaBridge: {
+        eip712ChainID: 5,
+      },
+    },
+    query: {
+      sygmaBasicFeeHandler: {
+        assetFees: jest.fn(),
+      },
+    },
+  },
+} as Partial<ApiPromise>;
+
+const calculateBasicFeeMock = jest.spyOn(Substrate, 'getBasicFee').mockResolvedValue({
+  fee: BigNumber.from('100'),
+  type: FeeHandlerType.BASIC,
+});
+
+describe('Substrate asset transfer', () => {
+  let assetTransfer: SubstrateAssetTransfer;
+
+  beforeEach(async () => {
+    axiosMock.onGet(ConfigUrl.DEVNET).reply(200, testingConfigData);
+    assetTransfer = new SubstrateAssetTransfer();
+    await assetTransfer.init(mockApiPromise as ApiPromise, Environment.DEVNET);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createFungibleTransfer', () => {
+    it('Should return a valid Transfer object', () => {
+      const expectedVal = {
+        to: {
+          name: 'Sepolia',
+          chainId: 11155111,
+          id: 3,
+        },
+        from: {
+          name: 'Mumbai',
+          chainId: 80001,
+          id: 2,
+        },
+        resource: {
+          resourceId: '0x0000000000000000000000000000000000000000000000000000000000000300',
+          address: '0x3690601896C289be2d894c3d1213405310D0a25C',
+          type: 'fungible',
+          symbol: 'LR',
+          decimals: 18,
+        },
+        sender: '0x3690601896C289be2d894c3d1213405310D0a25C',
+        recipient: '0x557abEc0cb31Aa925577441d54C090987c2ED818',
+        amount: {
+          amount: '200',
+        },
+      };
+
+      const actualVal = assetTransfer.createFungibleTransfer(
+        '0x3690601896C289be2d894c3d1213405310D0a25C',
+        11155111,
+        '0x557abEc0cb31Aa925577441d54C090987c2ED818',
+        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        200,
+      );
+
+      expect(actualVal).toStrictEqual(expectedVal);
+    });
+  });
+
+  describe('getFee', () => {
+    it('Should successfully get basic fee', async function () {
+      feeHandlerAddressFunction.mockResolvedValue('0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622');
+
+      const transfer = assetTransfer.createFungibleTransfer(
+        '0x3690601896C289be2d894c3d1213405310D0a25C',
+        11155111,
+        '0x557abEc0cb31Aa925577441d54C090987c2ED818',
+        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        200,
+      );
+
+      const fee = await assetTransfer.getFee(transfer);
+
+      expect(fee).toEqual({
+        fee: BigNumber.from('100'),
+        type: FeeHandlerType.BASIC,
+        handlerAddress: '0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622',
+      });
+      expect(calculateBasicFeeMock).toBeCalled();
+      expect(calculateBasicFeeMock).toBeCalledWith({
+        basicFeeHandlerAddress: '0xC2a1E379E2d255F42f3F8cA7Be32E3C3E1767622',
+        toDomainID: transfer.to.id,
+        fromDomainID: transfer.from.id,
+        provider: mockProvider,
+        resourceID: transfer.resource.resourceId,
+        sender: transfer.sender,
+      });
+    });
+
+    it('Should throw error for unsupported fee handler', async function () {
+      feeHandlerAddressFunction.mockResolvedValue('0xunsupported');
+
+      const transfer = assetTransfer.createFungibleTransfer(
+        '0x3690601896C289be2d894c3d1213405310D0a25C',
+        11155111,
+        '0x557abEc0cb31Aa925577441d54C090987c2ED818',
+        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        200,
+      );
+
+      try {
+        await assetTransfer.getFee(transfer);
+        fail('error not thrown');
+      } catch (e) {
+        expect(e).toEqual(new Error('Unsupported fee handler type'));
+      }
+    });
+  });
+
+  describe('buildTransferTransaction', () => {
+    it('Should build fungible transfer tx if resource type FUNGIBLE', function () {
+      const transfer = assetTransfer.createFungibleTransfer(
+        '0x3690601896C289be2d894c3d1213405310D0a25C',
+        11155111,
+        '0x557abEc0cb31Aa925577441d54C090987c2ED818',
+        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        200,
+      );
+
+      const fee = {
+        fee: BigNumber.from('100'),
+        type: FeeHandlerType.BASIC,
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
+      };
+      const tx = assetTransfer.buildTransferTransaction(transfer, fee);
+
+      expect(tx).toBeDefined();
+    });
+  });
+
+  describe('buildTransferTransaction', () => {
+    it('Should build erc20 transfer tx if resource type FUNGIBLE', function () {
+      const transfer = assetTransfer.createFungibleTransfer(
+        '0x3690601896C289be2d894c3d1213405310D0a25C',
+        11155111,
+        '0x557abEc0cb31Aa925577441d54C090987c2ED818',
+        '0x0000000000000000000000000000000000000000000000000000000000000300',
+        200,
+      );
+
+      const fee = {
+        fee: BigNumber.from('100'),
+        type: FeeHandlerType.BASIC,
+        handlerAddress: '0xe495c86962DcA7208ECcF2020A273395AcE8da3e',
+      };
+      const tx = assetTransfer.buildTransferTransaction(transfer, fee);
+
+      expect(tx).toBeDefined();
+    });
+  });
+});

--- a/packages/sdk/test/constants.ts
+++ b/packages/sdk/test/constants.ts
@@ -213,7 +213,7 @@ export const testingConfigData = {
     {
       id: 3,
       chainId: 11155111,
-      name: 'ethereum',
+      name: 'Sepolia',
       type: 'evm',
       bridge: '0x59d52E04d4521C0e6C78310f4c4FF9167BA71d01',
       handlers: [
@@ -299,14 +299,14 @@ export const testingConfigData = {
       resources: [
         {
           resourceId: '0x0000000000000000000000000000000000000000000000000000000000001000',
-          type: 'erc20',
+          type: 'fungible',
           address: '',
           symbol: 'PHA',
           decimals: 18,
         },
         {
           resourceId: '0x0000000000000000000000000000000000000000000000000000000000000000',
-          type: 'erc20',
+          type: 'fungible',
           address: '',
           symbol: 'ERC20TST',
           decimals: 18,


### PR DESCRIPTION
## Description
Implemented a helper to construct a Transfer object.?

## Related Issue Or Context
Closes: #265 

Additionally I have improved the initialization of the SubstrateAssetTransfer class by programatically fetching the Eip712ChainId from the sygmaBridge pallet, instead of requiring users to provide this value manually.

## How Has This Been Tested? Testing details.
Manual testing of new helper in all the examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
