### PR TITLE
feat: Add network type to domain object

### DIFF
--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -65,7 +65,12 @@ export class Config {
   }
 
   public getDomains(): Array<Domain> {
-    return this.environment.domains.map(({ id, chainId, name }) => ({ id, chainId, name }));
+    return this.environment.domains.map(({ id, chainId, name, type }) => ({
+      id,
+      chainId,
+      name,
+      type,
+    }));
   }
 
   public getDomainResources(): Array<Resource> {

--- a/packages/sdk/src/types/types.ts
+++ b/packages/sdk/src/types/types.ts
@@ -1,9 +1,11 @@
 import { ParachainID, XcmMultiAssetIdType } from 'chains/Substrate/types';
+import { Network } from './config';
 
 export type Domain = {
   id: number;
   chainId: number;
   name: string;
+  type: Network;
 };
 
 export type Recipient = {

--- a/packages/sdk/test/chains/EVM/assetTransfer.test.ts
+++ b/packages/sdk/test/chains/EVM/assetTransfer.test.ts
@@ -9,6 +9,7 @@ import {
   Environment,
   NonFungible,
   Fungible,
+  Network,
 } from '../../../src/types';
 import { testingConfigData } from '../../constants';
 import { ConfigUrl } from '../../../src/constants';
@@ -79,11 +80,13 @@ describe('EVM asset transfer', () => {
       name: 'Sepolia',
       chainId: 11155111,
       id: 3,
+      type: Network.EVM,
     },
     from: {
       name: 'Mumbai',
       chainId: 80001,
       id: 2,
+      type: Network.EVM,
     },
     resource: {
       resourceId: '0x0000000000000000000000000000000000000000000000000000000000000300',
@@ -103,11 +106,13 @@ describe('EVM asset transfer', () => {
       name: 'Sepolia',
       chainId: 11155111,
       id: 3,
+      type: Network.EVM,
     },
     from: {
       name: 'Mumbai',
       chainId: 80001,
       id: 2,
+      type: Network.EVM,
     },
     resource: {
       resourceId: '0x0000000000000000000000000000000000000000000000000000000000000300',

--- a/packages/sdk/test/chains/Substrate/assetTransfer.test.ts
+++ b/packages/sdk/test/chains/Substrate/assetTransfer.test.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { ApiPromise } from '@polkadot/api';
 import { BN } from '@polkadot/util';
-import { FeeHandlerType, Environment, Transfer, Fungible, ResourceType } from '../../../src/types';
+import { FeeHandlerType, Environment, Transfer, Fungible, ResourceType, Network } from '../../../src/types';
 import { testingConfigData } from '../../constants';
 import { ConfigUrl } from '../../../src/constants';
 import { SubstrateAssetTransfer } from '../../../src/chains/Substrate';
@@ -67,11 +67,13 @@ describe('Substrate asset transfer', () => {
           name: 'Sepolia',
           chainId: 11155111,
           id: 3,
+          type: Network.EVM,
         },
         from: {
           name: 'rococo-phala',
           chainId: 400,
           id: 5,
+          type: Network.SUBSTRATE,
         },
         resource: {
           resourceId: '0x0000000000000000000000000000000000000000000000000000000000001000',
@@ -110,11 +112,13 @@ describe('Substrate asset transfer', () => {
           name: 'Sepolia',
           chainId: 11155111,
           id: 3,
+          type: Network.EVM,
         },
         from: {
           name: 'rococo-phala',
           chainId: 400,
           id: 5,
+          type: Network.SUBSTRATE,
         },
         resource: {
           resourceId: '0x0000000000000000000000000000000000000000000000000000000000001000',

--- a/packages/sdk/test/config/config.test.ts
+++ b/packages/sdk/test/config/config.test.ts
@@ -61,7 +61,7 @@ describe('Config', () => {
     const domains = config.getDomains();
 
     expect(domains).toEqual(
-      testingConfigData.domains.map(({ id, chainId, name }) => ({ id, chainId, name })),
+      testingConfigData.domains.map(({ id, chainId, name, type }) => ({ id, chainId, name, type })),
     );
   });
 });


### PR DESCRIPTION
## Description
Added the Network Type property to the `Domain` object

## Related Issue Or Context
Network type is required in consumers of the `getDomains` call to correctly implement the widget

## How Has This Been Tested? Testing details.
Expanded the `Domain` type to also include the network type

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
