### PR TITLE
fix: getTransferStatusData returning data

### DIFF
--- a/packages/sdk/src/types/types.ts
+++ b/packages/sdk/src/types/types.ts
@@ -91,6 +91,8 @@ export type TransferStatus = 'pending' | 'executed' | 'failed';
 export type TransferStatusResponse = {
   status: TransferStatus;
   explorerUrl: string;
+  fromDomainId: number;
+  toDomainId: number;
 };
 
 export type RouteIndexerType = {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -44,6 +44,7 @@ export async function getTransferStatusData(
     const data = (await response.json()) as (Record<string, unknown> & {
       status: TransferStatus;
       toDomainId: number;
+      fromDomainId: number;
     })[];
 
     if (domainId) {
@@ -53,11 +54,15 @@ export async function getTransferStatusData(
 
       return {
         status: record.status,
+        fromDomainId: record.fromDomainId,
+        toDomainId: record.toDomainId,
         explorerUrl,
       };
     }
     return data.map(record => ({
       status: record.status,
+      fromDomainId: record.fromDomainId,
+      toDomainId: record.toDomainId,
       explorerUrl,
     }));
   } catch (err) {


### PR DESCRIPTION
figure out there is missing data while calling `getTransferStatusData` you get an array of statuses but you cannot know what this data represents