### PR TITLE
feat: Add `ParachainID` to `SubstrateConfig`

### DIFF
--- a/packages/sdk/src/chains/Substrate/types/index.ts
+++ b/packages/sdk/src/chains/Substrate/types/index.ts
@@ -50,4 +50,8 @@ export enum PolkadotParachain {
   COMPOSABLE = 2019,
 }
 
-export type ParachainID = KusamaParachain | PolkadotParachain | number;
+export enum RococoParachain {
+  RHALA = 2004,
+}
+
+export type ParachainID = KusamaParachain | PolkadotParachain | RococoParachain | number;

--- a/packages/sdk/src/config/localConfig.ts
+++ b/packages/sdk/src/config/localConfig.ts
@@ -141,7 +141,7 @@ export const localConfig: RawConfig = {
       nativeTokenDecimals: BigInt(18),
       blockConfirmations: 1,
       bridge: '0x',
-      parachainId: 0, // ? what is the local parachain id
+      parachainId: 0, // local setup is not parachain
       handlers: [
         {
           type: ResourceType.FUNGIBLE,

--- a/packages/sdk/src/config/localConfig.ts
+++ b/packages/sdk/src/config/localConfig.ts
@@ -141,6 +141,7 @@ export const localConfig: RawConfig = {
       nativeTokenDecimals: BigInt(18),
       blockConfirmations: 1,
       bridge: '0x',
+      parachainId: 0, // ? what is the local parachain id
       handlers: [
         {
           type: ResourceType.FUNGIBLE,

--- a/packages/sdk/src/types/config.ts
+++ b/packages/sdk/src/types/config.ts
@@ -1,3 +1,4 @@
+import type { ParachainID } from 'chains/Substrate/index.js';
 import type { FeeHandlerType, Resource, ResourceType } from './types.js';
 
 export enum Environment {
@@ -44,6 +45,7 @@ export interface EthereumConfig extends BaseConfig<Network.EVM> {
 
 export interface SubstrateConfig extends BaseConfig<Network.SUBSTRATE> {
   handlers: Array<Handler>;
+  parachainId: ParachainID;
 }
 
 export interface RawConfig {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`SubstrateConfig` didn't provide Parachain ID of a chain. It is needed because widget is using it to index Api promise objects.

## Related Issue Or Context
https://github.com/sygmaprotocol/sygma-widget/pull/134#issuecomment-2018551559

## Types of changes
- [x] Added ParachainID to config interface
