### PR TITLE
chore: Add semifungible type

### DIFF
--- a/packages/sdk/src/types/types.ts
+++ b/packages/sdk/src/types/types.ts
@@ -18,6 +18,7 @@ export enum ResourceType {
   NON_FUNGIBLE = 'nonfungible',
   PERMISSIONED_GENERIC = 'permissionedGeneric',
   PERMISSIONLESS_GENERIC = 'permissionlessGeneric',
+  SEMI_FUNGIBLE = 'semifungible',
 }
 
 export enum SubstrateParachain {


### PR DESCRIPTION
Added `semifungible` to `ResourceType` enum. 

closes #412 