### PR TITLE
fix: import for utils on core package

### DIFF
--- a/packages/core/src/multicall.ts
+++ b/packages/core/src/multicall.ts
@@ -4,8 +4,7 @@ import {
   FeeHandlerRouter__factory,
 } from '@buildwithsygma/sygma-contracts';
 import { Web3Provider } from '@ethersproject/providers';
-import { Contract } from 'ethers';
-import { defaultAbiCoder } from 'ethers/lib/utils';
+import { Contract, utils } from 'ethers';
 
 import MulticallAbi from './abi/Multicall.json';
 import type { Eip1193Provider, FeeHandlerType, RouteIndexerType } from './types.js';
@@ -232,7 +231,7 @@ export async function getFeeHandlerAddressesOfRoutes(params: {
 
     destination.set(
       route.resourceId,
-      defaultAbiCoder.decode(['address'], results.returnData[idx]).toString(),
+      utils.defaultAbiCoder.decode(['address'], results.returnData[idx]).toString(),
     );
   });
 
@@ -279,7 +278,7 @@ export async function getFeeHandlerTypeOfRoutes(params: {
       }
     }
 
-    const feeHandlerType = defaultAbiCoder.decode(
+    const feeHandlerType = utils.defaultAbiCoder.decode(
       ['string'],
       results.returnData[idx],
     )[0] as unknown as FeeHandlerType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently if we want to use some of the utils helpers functions from the core package, calling them will trigger import errors from `multicall.js` file

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
