### PR TITLE
fix: `optionalMessage` and `optionalGas` encoding

### DIFF
--- a/packages/evm/src/utils/assetTransferHelpers.ts
+++ b/packages/evm/src/utils/assetTransferHelpers.ts
@@ -104,13 +104,11 @@ export function createFungibleDepositData(depositParams: FungbileDepositParams):
   const zeroPaddedAddrLen = hexZeroPad(addressLenInHex, HEX_PADDING);
   let depositData = concat([zeroPaddedAmount, zeroPaddedAddrLen, recipientAddressSerialized]);
 
-  if (optionalGas) {
+  if (optionalMessage !== undefined && optionalGas !== undefined) {
     const optionalGasInHex = BigNumber.from(optionalGas).toHexString();
     const zeroPaddedOptionalGas = hexZeroPad(optionalGasInHex, HEX_PADDING);
     depositData = concat([depositData, zeroPaddedOptionalGas]);
-  }
 
-  if (optionalMessage) {
     const { transactionId, actions, receiver } = optionalMessage;
     const abiCoder = new AbiCoder();
 


### PR DESCRIPTION
## Description
`optionalGas` when set to 0 is not encoded by evm SDK. This PR fixes the encoding issue

## Related Issue Or Context
#535 

Closes: #535 

## How Has This Been Tested? Testing details.
- [ ] Add encoding unit test 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [X] I have updated the documentation locally and in chainbridge-docs.
- [X] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
