### PR TITLE
feat(evm): Expanding SDK to support Native transfer with optional con…

### DIFF
--- a/examples/evm-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-fungible-transfer/src/transfer.ts
@@ -18,7 +18,7 @@ if (!privateKey) {
 const SEPOLIA_CHAIN_ID = 11155111;
 const AMOY_CHAIN_ID = 84532;
 const RESOURCE_ID =
-  "0x0000000000000000000000000000000000000000000000000000000000001200";
+  "0x1000000000000000000000000000000000000000000000000000000000000000";
 const SEPOLIA_RPC_URL =
   process.env.SEPOLIA_RPC_URL ||
   "https://eth-sepolia.g.alchemy.com/v2/MeCKDrpxLkGOn4LMlBa3cKy1EzzOzwzG";
@@ -43,7 +43,7 @@ export async function erc20Transfer(): Promise<void> {
     destination: AMOY_CHAIN_ID,
     sourceNetworkProvider: web3Provider as unknown as Eip1193Provider,
     resource: RESOURCE_ID,
-    amount: BigInt(1) * BigInt(1e6),
+    amount: BigInt(1) * BigInt(1e17),
     recipientAddress: destinationAddress,
     sourceAddress: sourceAddress,
     optionalGas: BigInt(500000),
@@ -57,7 +57,7 @@ export async function erc20Transfer(): Promise<void> {
     const response = await wallet.sendTransaction(approval);
     await response.wait();
     console.log(
-      `Approved, transaction: ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`,
+      `Approved, transaction: ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`
     );
   }
 
@@ -65,7 +65,7 @@ export async function erc20Transfer(): Promise<void> {
   const response = await wallet.sendTransaction(transferTx);
   await response.wait();
   console.log(
-    `Depositted, transaction:  ${getSygmaScanLink(response.hash, process.env.SYGMA_ENV)}`,
+    `Depositted, transaction:  ${getSygmaScanLink(response.hash, process.env.SYGMA_ENV)}`
   );
 }
 

--- a/examples/evm-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-fungible-transfer/src/transfer.ts
@@ -18,7 +18,7 @@ if (!privateKey) {
 const SEPOLIA_CHAIN_ID = 11155111;
 const BASE_SEPOLIA_CHAIN_ID = 84532;
 const RESOURCE_ID =
-  "0x1000000000000000000000000000000000000000000000000000000000000000";
+  "0x0000000000000000000000000000000000000000000000000000000000001200";
 const SEPOLIA_RPC_URL =
   process.env.SEPOLIA_RPC_URL ||
   "https://eth-sepolia.g.alchemy.com/v2/MeCKDrpxLkGOn4LMlBa3cKy1EzzOzwzG";
@@ -43,7 +43,7 @@ export async function erc20Transfer(): Promise<void> {
     destination: BASE_SEPOLIA_CHAIN_ID,
     sourceNetworkProvider: web3Provider as unknown as Eip1193Provider,
     resource: RESOURCE_ID,
-    amount: BigInt(1) * BigInt(1e17),
+    amount: BigInt(1) * BigInt(1e6),
     recipientAddress: destinationAddress,
     sourceAddress: sourceAddress,
     optionalGas: BigInt(500000),

--- a/examples/evm-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-fungible-transfer/src/transfer.ts
@@ -16,7 +16,7 @@ if (!privateKey) {
 }
 
 const SEPOLIA_CHAIN_ID = 11155111;
-const AMOY_CHAIN_ID = 84532;
+const BASE_SEPOLIA_CHAIN_ID = 84532;
 const RESOURCE_ID =
   "0x1000000000000000000000000000000000000000000000000000000000000000";
 const SEPOLIA_RPC_URL =
@@ -40,7 +40,7 @@ export async function erc20Transfer(): Promise<void> {
 
   const params: FungibleTransferParams = {
     source: SEPOLIA_CHAIN_ID,
-    destination: AMOY_CHAIN_ID,
+    destination: BASE_SEPOLIA_CHAIN_ID,
     sourceNetworkProvider: web3Provider as unknown as Eip1193Provider,
     resource: RESOURCE_ID,
     amount: BigInt(1) * BigInt(1e17),

--- a/packages/core/src/config/localConfig.ts
+++ b/packages/core/src/config/localConfig.ts
@@ -8,6 +8,7 @@ export const localConfig: SygmaConfig = {
       caipId: '',
       chainId: 1337,
       name: 'Ethereum 1',
+      nativeTokenAdapter: '',
       type: Network.EVM,
       bridge: '0x6CdE2Cd82a4F8B74693Ff5e194c19CA08c2d1c68',
       handlers: [
@@ -76,6 +77,7 @@ export const localConfig: SygmaConfig = {
       caipId: '',
       chainId: 1338,
       name: 'evm2',
+      nativeTokenAdapter: '',
       type: Network.EVM,
       bridge: '0x6CdE2Cd82a4F8B74693Ff5e194c19CA08c2d1c68',
       handlers: [

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -132,6 +132,7 @@ export type FeeHandler = {
 
 export interface EthereumConfig extends BaseConfig<Network.EVM> {
   handlers: Array<Handler>;
+  nativeTokenAdapter: string;
   feeRouter: string;
   feeHandlers: Array<FeeHandler>;
 }

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@buildwithsygma/core": "workspace:^",
-    "@buildwithsygma/sygma-contracts": "^2.8.0",
+    "@buildwithsygma/sygma-contracts": "^2.9.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@buildwithsygma/core": "workspace:^",
-    "@buildwithsygma/sygma-contracts": "^2.9.0",
+    "@buildwithsygma/sygma-contracts": "^2.10.1",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",

--- a/packages/evm/src/evmAssetTransfer.ts
+++ b/packages/evm/src/evmAssetTransfer.ts
@@ -7,8 +7,8 @@ import { constants, utils } from 'ethers';
 
 import { EvmTransfer } from './evmTransfer.js';
 import type { EvmAssetTransferParams, EvmFee, TransactionRequest } from './types.js';
-import { createTransactionRequest } from './utils/transaction.js';
 import { getTransactionOverrides } from './utils/depositFn.js';
+import { createTransactionRequest } from './utils/transaction.js';
 
 /**
  * Asset transfers in EVM

--- a/packages/evm/src/evmAssetTransfer.ts
+++ b/packages/evm/src/evmAssetTransfer.ts
@@ -7,8 +7,8 @@ import { constants, utils } from 'ethers';
 
 import { EvmTransfer } from './evmTransfer.js';
 import type { EvmAssetTransferParams, EvmFee, TransactionRequest } from './types.js';
-import { executeDeposit } from './utils/depositFn.js';
 import { createTransactionRequest } from './utils/transaction.js';
+import { getTransactionOverrides } from './utils/depositFn.js';
 
 /**
  * Asset transfers in EVM
@@ -72,16 +72,15 @@ export abstract class AssetTransfer extends EvmTransfer implements IAssetTransfe
     const hasBalance = await this.hasEnoughBalance(fee);
     if (!hasBalance) throw new Error('Insufficient token balance');
 
-    const transferTx = await executeDeposit(
-      this.destination.id.toString(),
+    const transferTransaction = await bridge.populateTransaction.deposit(
+      this.destinationDomain.id.toString(),
       this.resource.resourceId,
       this.getDepositData(),
-      fee,
-      bridge,
-      overrides,
+      '0x',
+      getTransactionOverrides(fee, overrides),
     );
 
-    return createTransactionRequest(transferTx);
+    return createTransactionRequest(transferTransaction);
   }
 
   /**

--- a/packages/evm/src/fungibleAssetTransfer.ts
+++ b/packages/evm/src/fungibleAssetTransfer.ts
@@ -1,4 +1,4 @@
-import type { EvmResource } from '@buildwithsygma/core';
+import type { EthereumConfig, EvmResource } from '@buildwithsygma/core';
 import { Config, FeeHandlerType, ResourceType, SecurityModel } from '@buildwithsygma/core';
 import {
   Bridge__factory,
@@ -189,12 +189,15 @@ class FungibleAssetTransfer extends AssetTransfer {
   protected async getNativeDepositTransaction(
     overrides?: ethers.Overrides,
   ): Promise<TransactionRequest> {
-    const domainConfig = this.config.getDomainConfig(this.source);
+    const domainConfig = this.config.getDomainConfig(this.source) as EthereumConfig;
     const provider = new Web3Provider(this.sourceNetworkProvider);
-    const bridge = Bridge__factory.connect(domainConfig.bridge, provider);
-    const handlerAddress = await bridge._resourceIDToHandlerAddress(this.resource.resourceId);
-    const nativeTokenAdapter = await NativeTokenAdapter__factory.connect(handlerAddress, provider);
+    const nativeTokenAdapter = await NativeTokenAdapter__factory.connect(
+      domainConfig.nativeTokenAdapter,
+      provider,
+    );
+
     const fee = await this.getFee();
+    fee.fee += this.transferAmount;
 
     const transferTransaction = await nativeTokenAdapter.populateTransaction.deposit(
       this.destination.id.toString(),

--- a/packages/evm/src/fungibleAssetTransfer.ts
+++ b/packages/evm/src/fungibleAssetTransfer.ts
@@ -7,7 +7,7 @@ import {
 } from '@buildwithsygma/sygma-contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import { BigNumber, constants, utils } from 'ethers';
-import type { ethers, PayableOverrides, PopulatedTransaction } from 'ethers';
+import type { ethers, PopulatedTransaction } from 'ethers';
 
 import { AssetTransfer } from './evmAssetTransfer.js';
 import type {

--- a/packages/evm/src/fungibleAssetTransfer.ts
+++ b/packages/evm/src/fungibleAssetTransfer.ts
@@ -86,7 +86,6 @@ class FungibleAssetTransfer extends AssetTransfer {
       amount: this.adjustedAmount,
       optionalGas: this.optionalGas,
       optionalMessage: this.optionalMessage,
-      isNativeToken: this.isNativeTransfer(),
     });
   }
 
@@ -196,6 +195,8 @@ class FungibleAssetTransfer extends AssetTransfer {
     const fee = await this.getFee();
     fee.fee += this.transferAmount;
 
+    const payableOverrides: ethers.PayableOverrides = { ...overrides, value: fee.fee };
+
     return await getNativeTokenDepositTransaction(
       {
         destinationNetworkId: this.destination.id.toString(),
@@ -207,7 +208,7 @@ class FungibleAssetTransfer extends AssetTransfer {
         depositData: this.getDepositData(),
       },
       nativeTokenAdapter,
-      overrides,
+      payableOverrides,
     );
   }
 

--- a/packages/evm/src/fungibleAssetTransfer.ts
+++ b/packages/evm/src/fungibleAssetTransfer.ts
@@ -6,14 +6,8 @@ import {
   NativeTokenAdapter__factory,
 } from '@buildwithsygma/sygma-contracts';
 import { Web3Provider } from '@ethersproject/providers';
-import {
-  BigNumber,
-  constants,
-  ethers,
-  PayableOverrides,
-  type PopulatedTransaction,
-  utils,
-} from 'ethers';
+import { BigNumber, constants, utils } from 'ethers';
+import type { ethers, PayableOverrides, PopulatedTransaction } from 'ethers';
 
 import { AssetTransfer } from './evmAssetTransfer.js';
 import type {
@@ -23,9 +17,9 @@ import type {
   TransactionRequest,
 } from './types.js';
 import { approve, getERC20Allowance } from './utils/approveAndCheckFns.js';
-import { createFungibleDepositData } from './utils/assetTransferHelpers.js';
-import { createTransactionRequest } from './utils/transaction.js';
+import { createAssetDepositData } from './utils/assetTransferHelpers.js';
 import { getTransactionOverrides } from './utils/depositFn.js';
+import { createTransactionRequest } from './utils/transaction.js';
 
 /**
  * @internal
@@ -86,7 +80,7 @@ class FungibleAssetTransfer extends AssetTransfer {
    * @returns {string}
    */
   protected getDepositData(): string {
-    return createFungibleDepositData({
+    return createAssetDepositData({
       destination: this.destination,
       recipientAddress: this.recipientAddress,
       amount: this.adjustedAmount,
@@ -191,7 +185,7 @@ class FungibleAssetTransfer extends AssetTransfer {
   ): Promise<TransactionRequest> {
     const domainConfig = this.config.getDomainConfig(this.source) as EthereumConfig;
     const provider = new Web3Provider(this.sourceNetworkProvider);
-    const nativeTokenAdapter = await NativeTokenAdapter__factory.connect(
+    const nativeTokenAdapter = NativeTokenAdapter__factory.connect(
       domainConfig.nativeTokenAdapter,
       provider,
     );

--- a/packages/evm/src/genericMessageTransfer.ts
+++ b/packages/evm/src/genericMessageTransfer.ts
@@ -15,8 +15,9 @@ import { EvmTransfer } from './evmTransfer.js';
 import { getFeeInformation } from './fee/getFeeInformation.js';
 import type { GenericMessageTransferParams, TransactionRequest } from './types.js';
 import { createGenericCallDepositData } from './utils/genericTransferHelpers.js';
-import { executeDeposit } from './utils/index.js';
+
 import { createTransactionRequest } from './utils/transaction.js';
+import { getTransactionOverrides } from './utils/depositFn.js';
 
 /**
  * @internal
@@ -143,16 +144,15 @@ class GenericMessageTransfer<
     const feeData = await this.getFee();
     const depositData = this.getDepositData();
 
-    const transaction = await executeDeposit(
+    const transferTransaction = await bridgeInstance.populateTransaction.deposit(
       this.destination.id.toString(),
       this.resource.resourceId,
       depositData,
-      feeData,
-      bridgeInstance,
-      overrides,
+      '0x',
+      getTransactionOverrides(feeData, overrides),
     );
 
-    return createTransactionRequest(transaction);
+    return createTransactionRequest(transferTransaction);
   }
   /**
    * Get prepared additional deposit data

--- a/packages/evm/src/genericMessageTransfer.ts
+++ b/packages/evm/src/genericMessageTransfer.ts
@@ -14,10 +14,9 @@ import { constants } from 'ethers';
 import { EvmTransfer } from './evmTransfer.js';
 import { getFeeInformation } from './fee/getFeeInformation.js';
 import type { GenericMessageTransferParams, TransactionRequest } from './types.js';
-import { createGenericCallDepositData } from './utils/genericTransferHelpers.js';
-
-import { createTransactionRequest } from './utils/transaction.js';
 import { getTransactionOverrides } from './utils/depositFn.js';
+import { createGenericCallDepositData } from './utils/genericTransferHelpers.js';
+import { createTransactionRequest } from './utils/transaction.js';
 
 /**
  * @internal

--- a/packages/evm/src/nonFungibleAssetTransfer.ts
+++ b/packages/evm/src/nonFungibleAssetTransfer.ts
@@ -35,7 +35,6 @@ class NonFungibleAssetTransfer extends AssetTransfer {
       destination: this.destination,
       recipientAddress: this.recipientAddress,
       tokenId: this.tokenId,
-      isNativeToken: false,
     });
   }
 

--- a/packages/evm/src/nonFungibleAssetTransfer.ts
+++ b/packages/evm/src/nonFungibleAssetTransfer.ts
@@ -35,6 +35,7 @@ class NonFungibleAssetTransfer extends AssetTransfer {
       destination: this.destination,
       recipientAddress: this.recipientAddress,
       tokenId: this.tokenId,
+      isNativeToken: false,
     });
   }
 

--- a/packages/evm/src/nonFungibleAssetTransfer.ts
+++ b/packages/evm/src/nonFungibleAssetTransfer.ts
@@ -9,7 +9,7 @@ import { providers } from 'ethers';
 
 import { AssetTransfer } from './evmAssetTransfer.js';
 import type { EvmFee, NonFungibleTransferParams, TransactionRequest } from './types.js';
-import { createFungibleDepositData } from './utils/assetTransferHelpers.js';
+import { createAssetDepositData } from './utils/assetTransferHelpers.js';
 import { approve, isApproved } from './utils/index.js';
 import { createTransactionRequest } from './utils/transaction.js';
 
@@ -31,7 +31,7 @@ class NonFungibleAssetTransfer extends AssetTransfer {
    * @returns {string}
    */
   protected getDepositData(): string {
-    return createFungibleDepositData({
+    return createAssetDepositData({
       destination: this.destination,
       recipientAddress: this.recipientAddress,
       tokenId: this.tokenId,

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -102,3 +102,12 @@ export interface GenericMessageTransferParams<
   destinationContractAddress: string;
   maxFee: bigint;
 }
+
+export type NativeTokenDepositArgsWithoutMessage = [string, string];
+export type NativeTokenDepositArgsWithGeneralMessage = [string, string];
+export type NativeTokenDepositArgsWithEVMMessage = [string, string, bigint, string];
+export type NativeTokenDepositMethods =
+  | 'deposit'
+  | 'depositToEVM'
+  | 'depositGeneral'
+  | 'depositToEVMWithMessage';

--- a/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
+++ b/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
@@ -26,7 +26,6 @@ describe('createERCDepositData', () => {
         chainId: 1,
         id: 1,
       },
-      isNativeToken: false,
     });
 
     expect(depositData).toEqual(expectedDepositData);
@@ -49,7 +48,6 @@ describe('createERCDepositData', () => {
         id: 1,
         parachainId: 2004,
       },
-      isNativeToken: false,
     });
 
     expect(depositData).toEqual(expectedDepositData);
@@ -71,7 +69,6 @@ describe('createERCDepositData', () => {
         chainId: 1,
         id: 1,
       },
-      isNativeToken: false,
     });
     expect(depositData).toEqual(expectedDepositData);
   });

--- a/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
+++ b/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
@@ -27,7 +27,6 @@ describe('createERCDepositData', () => {
         id: 1,
       },
       isNativeToken: false,
-      q,
     });
 
     expect(depositData).toEqual(expectedDepositData);

--- a/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
+++ b/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
@@ -3,7 +3,7 @@ import { arrayify } from '@ethersproject/bytes';
 import { utils } from 'ethers';
 
 import {
-  createFungibleDepositData,
+  createAssetDepositData,
   createSubstrateMultiLocationObject,
   serializeEvmAddress,
   serializeSubstrateAddress,
@@ -16,7 +16,7 @@ describe('createERCDepositData', () => {
     const expectedDepositData =
       '0x000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000141234567890123456789012345678901234567890';
 
-    const depositData = createFungibleDepositData({
+    const depositData = createAssetDepositData({
       recipientAddress,
       amount,
       destination: {
@@ -37,7 +37,7 @@ describe('createERCDepositData', () => {
     const expectedDepositData =
       '0x00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000027010200511f0100fac48520983815e2022ded67ca8d27b73d51b1b022284c48b4eccbb7a328d80f';
 
-    const depositData = createFungibleDepositData({
+    const depositData = createAssetDepositData({
       recipientAddress,
       amount,
       destination: {
@@ -59,7 +59,7 @@ describe('createERCDepositData', () => {
     const expectedDepositData =
       '0x0000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000002a746231717366797a6c3932707637776b79616a3074666a6474777663736a383430703030346a676c7670';
 
-    const depositData = createFungibleDepositData({
+    const depositData = createAssetDepositData({
       recipientAddress,
       amount: tokenAmount,
       destination: {

--- a/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
+++ b/packages/evm/src/utils/__test__/assetTransferHelpers.test.ts
@@ -26,6 +26,8 @@ describe('createERCDepositData', () => {
         chainId: 1,
         id: 1,
       },
+      isNativeToken: false,
+      q,
     });
 
     expect(depositData).toEqual(expectedDepositData);
@@ -48,6 +50,7 @@ describe('createERCDepositData', () => {
         id: 1,
         parachainId: 2004,
       },
+      isNativeToken: false,
     });
 
     expect(depositData).toEqual(expectedDepositData);
@@ -69,6 +72,7 @@ describe('createERCDepositData', () => {
         chainId: 1,
         id: 1,
       },
+      isNativeToken: false,
     });
     expect(depositData).toEqual(expectedDepositData);
   });

--- a/packages/evm/src/utils/__test__/depositFns.test.ts
+++ b/packages/evm/src/utils/__test__/depositFns.test.ts
@@ -1,144 +1,18 @@
 import { FeeHandlerType } from '@buildwithsygma/core';
-import type { Bridge, ERC721MinterBurnerPauser } from '@buildwithsygma/sygma-contracts';
-import { type ContractReceipt, type PopulatedTransaction } from 'ethers';
 
 import type { EvmFee } from '../../types.js';
-import * as EVM from '../depositFn.js';
-
-jest.mock(
-  '@buildwithsygma/sygma-contracts',
-  () =>
-    ({
-      ...jest.requireActual('@buildwithsygma/sygma-contracts'),
-      Bridge__factory: {
-        connect: jest.fn() as unknown as Bridge,
-      },
-      ERC721MinterBurnerPauser__factory: {
-        connect: jest.fn() as unknown as ERC721MinterBurnerPauser,
-      },
-    }) as unknown,
-);
+import { getTransactionOverrides } from '../depositFn.js';
 
 // Define a test suite
-describe('deposit functions', () => {
-  let domainId: string;
-  let resourceId: string;
-  let depositData: string;
-  let feeData: EvmFee;
-
-  beforeEach(() => {
-    domainId = 'domainId';
-    resourceId = 'resourceId';
-    depositData = 'depositData';
-    feeData = {
+describe('getTransactionOverrides', () => {
+  it('should assign correct values', () => {
+    const evmFee: EvmFee = {
+      fee: 1n,
       type: FeeHandlerType.BASIC,
-      fee: BigInt('100'),
-      tokenAddress: '0x00',
-      handlerAddress: '0x9867',
+      handlerAddress: '',
     };
 
-    jest.clearAllMocks();
-  });
-  describe('executeDeposit', () => {
-    it('should successfully execute deposit', async () => {
-      const bridgeInstance = {
-        populateTransaction: {
-          deposit: jest.fn().mockResolvedValueOnce({
-            wait: jest.fn().mockResolvedValueOnce({} as ContractReceipt),
-          } as unknown as PopulatedTransaction),
-        },
-      };
-
-      const result = await EVM.executeDeposit(
-        domainId,
-        resourceId,
-        depositData,
-        feeData,
-        bridgeInstance as unknown as Bridge,
-      );
-
-      expect(result).toBeDefined();
-      expect(bridgeInstance.populateTransaction.deposit).toHaveBeenCalledTimes(1);
-    });
-
-    it('should successfully call deposit method on contract without overrides', async () => {
-      const bridgeInstance = {
-        populateTransaction: {
-          deposit: jest.fn().mockResolvedValueOnce({
-            wait: jest.fn().mockResolvedValueOnce({} as ContractReceipt),
-          } as unknown as PopulatedTransaction),
-        },
-      };
-
-      const result = await EVM.executeDeposit(
-        domainId,
-        resourceId,
-        depositData,
-        feeData,
-        bridgeInstance as unknown as Bridge,
-      );
-
-      expect(result).toBeDefined();
-      expect(bridgeInstance.populateTransaction.deposit).toHaveBeenCalledTimes(1);
-      expect(bridgeInstance.populateTransaction.deposit).toHaveBeenCalledWith(
-        'domainId',
-        'resourceId',
-        'depositData',
-        '0x',
-        { value: feeData.fee, gasLimit: EVM.ASSET_TRANSFER_GAS_LIMIT },
-      );
-    });
-
-    it('should successfully call deposit method on contract  without overrides and with dynamic (oracle) fee', async () => {
-      feeData = {
-        type: FeeHandlerType.PERCENTAGE,
-        fee: BigInt('100'),
-        tokenAddress: '0x00',
-        handlerAddress: '0x123',
-      };
-      const bridgeInstance = {
-        populateTransaction: {
-          deposit: jest.fn().mockResolvedValueOnce({
-            wait: jest.fn().mockResolvedValueOnce({} as ContractReceipt),
-          } as unknown as PopulatedTransaction),
-        },
-      };
-
-      const result = await EVM.executeDeposit(
-        domainId,
-        resourceId,
-        depositData,
-        feeData,
-        bridgeInstance as unknown as Bridge,
-      );
-
-      expect(result).toBeDefined();
-      expect(bridgeInstance.populateTransaction.deposit).toHaveBeenCalledTimes(1);
-      expect(bridgeInstance.populateTransaction.deposit).toHaveBeenCalledWith(
-        'domainId',
-        'resourceId',
-        'depositData',
-        '0x',
-        { gasLimit: EVM.ASSET_TRANSFER_GAS_LIMIT, value: 0 },
-      );
-    });
-
-    it('should handle error on execute deposit', async () => {
-      const bridgeInstance = {
-        populateTransaction: {
-          deposit: jest.fn().mockRejectedValueOnce(new Error('Deposit failed')),
-        },
-      };
-
-      await expect(
-        EVM.executeDeposit(
-          domainId,
-          resourceId,
-          depositData,
-          feeData,
-          bridgeInstance as unknown as Bridge,
-        ),
-      ).rejects.toThrowError('Deposit failed');
-    });
+    const overrides = getTransactionOverrides(evmFee);
+    expect(overrides.value).toEqual(evmFee.fee);
   });
 });

--- a/packages/evm/src/utils/assetTransferHelpers.ts
+++ b/packages/evm/src/utils/assetTransferHelpers.ts
@@ -18,7 +18,6 @@ interface AssetDepositParams {
   tokenId?: string;
   optionalGas?: bigint;
   optionalMessage?: FungibleTransferOptionalMessage;
-  isNativeToken: boolean;
 }
 
 export function serializeEvmAddress(evmAddress: `0x${string}`): Uint8Array {
@@ -112,15 +111,8 @@ export function encodeOptionalMessage(optionalMessage: FungibleTransferOptionalM
 }
 
 export function createAssetDepositData(depositParams: AssetDepositParams): string {
-  const {
-    isNativeToken,
-    recipientAddress,
-    destination,
-    amount,
-    tokenId,
-    optionalGas,
-    optionalMessage,
-  } = depositParams;
+  const { recipientAddress, destination, amount, tokenId, optionalGas, optionalMessage } =
+    depositParams;
 
   const recipientAddressSerialized: Uint8Array = serializeDestinationAddress(
     recipientAddress,
@@ -137,12 +129,7 @@ export function createAssetDepositData(depositParams: AssetDepositParams): strin
   const addressLenInHex = BigNumber.from(recipientAddressSerialized.length).toHexString();
   const zeroPaddedAddrLen = hexZeroPad(addressLenInHex, HEX_PADDING);
 
-  let depositData;
-  if (isNativeToken) {
-    depositData = concat([zeroPaddedAddrLen, recipientAddressSerialized]);
-  } else {
-    depositData = concat([zeroPaddedAmount, zeroPaddedAddrLen, recipientAddressSerialized]);
-  }
+  let depositData = concat([zeroPaddedAmount, zeroPaddedAddrLen, recipientAddressSerialized]);
 
   if (optionalMessage !== undefined && optionalGas !== undefined) {
     const optionalGasInHex = BigNumber.from(optionalGas).toHexString();

--- a/packages/evm/src/utils/assetTransferHelpers.ts
+++ b/packages/evm/src/utils/assetTransferHelpers.ts
@@ -11,7 +11,7 @@ import type { FungibleTransferOptionalMessage } from '../types.js';
 const ACTIONS_ARRAY_ABI =
   'tuple(uint256 nativeValue, address callTo, address approveTo, address tokenSend, address tokenReceive, bytes data)[]';
 
-interface FungbileDepositParams {
+interface AssetDepositParams {
   destination: Domain;
   recipientAddress: string;
   amount?: bigint;
@@ -66,7 +66,7 @@ export function serializeSubstrateAddress(
   return registry.createType('MultiLocation', JSON.parse(multilocationObject)).toU8a();
 }
 
-export function createFungibleDepositData(depositParams: FungbileDepositParams): string {
+export function createAssetDepositData(depositParams: AssetDepositParams): string {
   const { recipientAddress, destination, amount, tokenId, optionalGas, optionalMessage } =
     depositParams;
   let recipientAddressSerialized: Uint8Array;

--- a/packages/evm/src/utils/depositFn.ts
+++ b/packages/evm/src/utils/depositFn.ts
@@ -1,53 +1,22 @@
 import { FeeHandlerType } from '@buildwithsygma/core';
-import type { Bridge } from '@buildwithsygma/sygma-contracts';
-import type { PopulatedTransaction, ethers } from 'ethers';
+import type { ethers } from 'ethers';
 import { BigNumber } from 'ethers';
 
 import type { EvmFee } from '../types.js';
 
 export const ASSET_TRANSFER_GAS_LIMIT: BigNumber = BigNumber.from(300000);
 
-/**
- * Executes a deposit operation using the specified parameters and returns a populated transaction.
- *
- *
- * @category Bridge deposit
- * @param {string} domainId - The unique identifier for destination network.
- * @param {string} resourceId - The resource ID associated with the token.
- * @param {string} depositData - The deposit data required for the operation.
- * @param {FeeDataResult} feeData - The fee data result for the deposit operation.
- * @param {Bridge} bridgeInstance - The bridge instance used to perform the deposit operation.
- * @returns {Promise<PopulatedTransaction>} Unsigned transaction
- */
-export const executeDeposit = async (
-  domainId: string,
-  resourceId: string,
-  depositData: string,
-  feeData: EvmFee,
-  bridgeInstance: Bridge,
-  overrides?: ethers.PayableOverrides,
-): Promise<PopulatedTransaction> => {
-  const transactionSettings = {
-    /**
-     * @remarks
-     * "twap" and "basic" both deduct in native currency
-     */
-    value: feeData.type == FeeHandlerType.PERCENTAGE ? 0 : feeData.fee,
+export function getTransactionOverrides(
+  fee: EvmFee,
+  overrides?: ethers.Overrides,
+): ethers.Overrides {
+  const sygmaOverrides = {
     gasLimit: ASSET_TRANSFER_GAS_LIMIT,
+    value: fee.type === FeeHandlerType.PERCENTAGE ? 0 : fee.fee,
   };
 
-  const payableOverrides = {
-    ...transactionSettings,
+  return {
+    ...sygmaOverrides,
     ...overrides,
   };
-
-  const depositTransaction = await bridgeInstance.populateTransaction.deposit(
-    domainId,
-    resourceId,
-    depositData,
-    '0x',
-    payableOverrides,
-  );
-
-  return depositTransaction;
-};
+}

--- a/packages/evm/src/utils/depositFn.ts
+++ b/packages/evm/src/utils/depositFn.ts
@@ -9,7 +9,7 @@ export const ASSET_TRANSFER_GAS_LIMIT: BigNumber = BigNumber.from(300000);
 export function getTransactionOverrides(
   fee: EvmFee,
   overrides?: ethers.Overrides,
-): ethers.Overrides {
+): ethers.PayableOverrides {
   const sygmaOverrides = {
     gasLimit: ASSET_TRANSFER_GAS_LIMIT,
     value: fee.type === FeeHandlerType.PERCENTAGE ? 0 : fee.fee,

--- a/packages/evm/src/utils/nativeTokenDepositHelpers.ts
+++ b/packages/evm/src/utils/nativeTokenDepositHelpers.ts
@@ -1,0 +1,125 @@
+import type { ParachainId } from '@buildwithsygma/core';
+import { Network } from '@buildwithsygma/core';
+import type { NativeTokenAdapter } from '@buildwithsygma/sygma-contracts';
+import { hexlify } from '@ethersproject/bytes';
+import type { ethers } from 'ethers';
+
+import type {
+  FungibleTransferOptionalMessage,
+  NativeTokenDepositArgsWithEVMMessage,
+  NativeTokenDepositArgsWithGeneralMessage,
+  NativeTokenDepositArgsWithoutMessage,
+  NativeTokenDepositMethods,
+  TransactionRequest,
+} from '../types.js';
+
+import { serializeDestinationAddress, encodeOptionalMessage } from './assetTransferHelpers.js';
+import { createTransactionRequest } from './transaction.js';
+
+export function getNativeTokenDepositMethod(
+  destinationNetworkType: Network,
+  optionalMessage?: FungibleTransferOptionalMessage,
+): NativeTokenDepositMethods {
+  if (!optionalMessage) {
+    if (destinationNetworkType === Network.EVM) {
+      return 'depositToEVM';
+    }
+    return 'deposit';
+  } else {
+    if (destinationNetworkType === Network.EVM) {
+      return 'depositToEVMWithMessage';
+    }
+  }
+
+  throw new Error('Unsupported deposit method.');
+}
+
+interface NativeDepositParams {
+  method: NativeTokenDepositMethods;
+  recipientAddress: string;
+  destinationNetworkType: Network;
+  destinationNetworkId: string;
+  parachainId?: ParachainId;
+  optionalMessage?: FungibleTransferOptionalMessage;
+  optionalGas?: bigint;
+  depositData: string;
+}
+
+export function getNativeTokenDepositContractArgs(
+  args: NativeDepositParams,
+):
+  | NativeTokenDepositArgsWithoutMessage
+  | NativeTokenDepositArgsWithEVMMessage
+  | NativeTokenDepositArgsWithGeneralMessage {
+  const {
+    method,
+    destinationNetworkId,
+    recipientAddress,
+    destinationNetworkType,
+    parachainId,
+    optionalMessage,
+    optionalGas,
+    depositData,
+  } = args;
+
+  switch (method) {
+    case 'deposit':
+    case 'depositToEVM':
+      return [
+        destinationNetworkId,
+        hexlify(serializeDestinationAddress(recipientAddress, destinationNetworkType, parachainId)),
+      ];
+    case 'depositToEVMWithMessage':
+      return [
+        destinationNetworkId,
+        recipientAddress,
+        optionalGas!,
+        encodeOptionalMessage(optionalMessage!),
+      ];
+    case 'depositGeneral':
+      return [destinationNetworkId, depositData];
+  }
+}
+
+export async function getNativeTokenDepositTransaction(
+  depositParams: Omit<NativeDepositParams, 'method'>,
+  nativeTokenAdapter: NativeTokenAdapter,
+  overrides?: ethers.Overrides,
+): Promise<TransactionRequest> {
+  const method = getNativeTokenDepositMethod(
+    depositParams.destinationNetworkType,
+    depositParams.optionalMessage,
+  );
+
+  const args = getNativeTokenDepositContractArgs({
+    method,
+    ...depositParams,
+  });
+
+  switch (method) {
+    case 'deposit':
+    case 'depositToEVM':
+      return createTransactionRequest(
+        await nativeTokenAdapter.populateTransaction[method](
+          ...(args as NativeTokenDepositArgsWithoutMessage),
+          overrides,
+        ),
+      );
+    case 'depositToEVMWithMessage':
+      return createTransactionRequest(
+        await nativeTokenAdapter.populateTransaction[method](
+          ...(args as NativeTokenDepositArgsWithEVMMessage),
+          overrides,
+        ),
+      );
+    case 'depositGeneral':
+      return createTransactionRequest(
+        await nativeTokenAdapter.populateTransaction[method](
+          ...(args as NativeTokenDepositArgsWithGeneralMessage),
+          overrides,
+        ),
+      );
+    default:
+      throw new Error('Unsupported method');
+  }
+}

--- a/packages/evm/src/utils/nativeTokenDepositHelpers.ts
+++ b/packages/evm/src/utils/nativeTokenDepositHelpers.ts
@@ -77,14 +77,14 @@ export function getNativeTokenDepositContractArgs(
         encodeOptionalMessage(optionalMessage!),
       ];
     case 'depositGeneral':
-      return [destinationNetworkId, depositData];
+      return [destinationNetworkId, `0x${depositData.substring(66)}`];
   }
 }
 
 export async function getNativeTokenDepositTransaction(
   depositParams: Omit<NativeDepositParams, 'method'>,
   nativeTokenAdapter: NativeTokenAdapter,
-  overrides?: ethers.Overrides,
+  overrides?: ethers.PayableOverrides,
 ): Promise<TransactionRequest> {
   const method = getNativeTokenDepositMethod(
     depositParams.destinationNetworkType,

--- a/packages/evm/src/utils/nativeTokenDepositHelpers.ts
+++ b/packages/evm/src/utils/nativeTokenDepositHelpers.ts
@@ -29,9 +29,9 @@ export function getNativeTokenDepositMethod(
     if (destinationNetworkType === Network.EVM) {
       return 'depositToEVMWithMessage';
     }
-  }
 
-  throw new Error('Unsupported deposit method.');
+    return 'depositGeneral';
+  }
 }
 
 interface NativeDepositParams {

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,7 +537,7 @@ __metadata:
   resolution: "@buildwithsygma/evm@workspace:packages/evm"
   dependencies:
     "@buildwithsygma/core": "workspace:^"
-    "@buildwithsygma/sygma-contracts": "npm:^2.9.0"
+    "@buildwithsygma/sygma-contracts": "npm:^2.10.1"
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/bytes": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -626,15 +626,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@buildwithsygma/sygma-contracts@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "@buildwithsygma/sygma-contracts@npm:2.9.0"
+"@buildwithsygma/sygma-contracts@npm:^2.10.1":
+  version: 2.10.1
+  resolution: "@buildwithsygma/sygma-contracts@npm:2.10.1"
   dependencies:
     "@openzeppelin/contracts": "npm:4.5.0"
     "@uniswap/v3-periphery": "npm:^1.4.4"
+    solmate: "npm:^6.2.0"
   peerDependencies:
     ethers: ">= 5.0.0"
-  checksum: 0f98a64da674e1264caaf429665a23b7db63365d7a8c5a38d8e23f0b728faecd6bfd3a0c43616bd4aa43133229324f14d4c3d0e2e24225d223574d5e94af9263
+  checksum: c6cddf6a427a4d3ab1321fbc21f9e47a64661823ffdb55db230ce9874878125735aad260d3aef454f7681f2d2f7d446882f82f1cf3e7f69209e183b69f375c4a
   languageName: node
   linkType: hard
 
@@ -10554,6 +10555,13 @@ __metadata:
   bin:
     solcjs: solcjs
   checksum: 28405adfba1f55603dc5b674630383bfbdbfab2d36deba2ff0a90c46cbc346bcabf0ed6175e12ae3c0b751ef082d0405ab42dcc24f88603a446e097a925d7425
+  languageName: node
+  linkType: hard
+
+"solmate@npm:^6.2.0":
+  version: 6.7.0
+  resolution: "solmate@npm:6.7.0"
+  checksum: 7c51286ac486de2cace00fd136a210d01e2dc28403373583ce5acd49178f1cf4421d3f3a945f28af36e7fcedcea194238b2b5eb53be78a04b9e04f32ea8d286f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,7 +537,7 @@ __metadata:
   resolution: "@buildwithsygma/evm@workspace:packages/evm"
   dependencies:
     "@buildwithsygma/core": "workspace:^"
-    "@buildwithsygma/sygma-contracts": "npm:^2.8.0"
+    "@buildwithsygma/sygma-contracts": "npm:^2.9.0"
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/bytes": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -626,7 +626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@buildwithsygma/sygma-contracts@npm:^2.8.0":
+"@buildwithsygma/sygma-contracts@npm:^2.9.0":
   version: 2.9.0
   resolution: "@buildwithsygma/sygma-contracts@npm:2.9.0"
   dependencies:


### PR DESCRIPTION
# Implementation details

With [PR#266](https://github.com/sygmaprotocol/sygma-solidity/pull/266), we introduced the ability to define contract calls together with native deposit. As SDK didn't integrate the initial implementation of native handlers, it needs to be expanded so it can be used to create:

Deposit of native currency (tokens)
Deposit of native currency (tokens) + contract call definition
The Native flow differs slightly from regular ERC20/721/1155, as the deposit transaction should not land on Bridge.sol but on NativeAdapter.sol contract. We have already expanded the testnet [shared configuration to have this as a new property of the domain](https://github.com/sygmaprotocol/sygma-shared-configuration/blob/main/testnet/shared-config-test.json#L10) - nativeTokenAdapter.

## Closes: #521 

# Testing details

Unit Tests: Develop unit tests that cover scenarios where both Native transfers and contract calls are involved.
Error Handling: Test how the SDK handles invalid or failed contract calls within the transaction flow.

# Acceptance Criteria



- [ ] The SDK supports interactions with the new NativeAdapter->NativeHandler, allowing for both Native transfers and optional contract calls within the same transaction.
- [ ] The SDK maintains backward compatibility and continues to function as expected with existing handlers.
- [ ] All new functionality is covered by tests, ensuring reliable and consistent behavior.