### PR TITLE
fix: remove `process` depedency which causes browser integration failure

### DIFF
--- a/examples/bitcoin-to-evm-fungible-transfer/src/environment.d.ts
+++ b/examples/bitcoin-to-evm-fungible-transfer/src/environment.d.ts
@@ -1,4 +1,4 @@
-import type { Environment } from './types.js';
+import type { Environment } from "@buildwithsygma/core";
 
 declare global {
   namespace NodeJS {

--- a/examples/bitcoin-to-evm-fungible-transfer/src/transfer.p2tr.ts
+++ b/examples/bitcoin-to-evm-fungible-transfer/src/transfer.p2tr.ts
@@ -13,9 +13,8 @@ import { initEccLib, networks, Signer } from "bitcoinjs-lib";
 import dotenv from "dotenv";
 import * as tinysecp from "tiny-secp256k1";
 
-import {
-  calculateSize,
-} from "./blockstreamApi.js";
+import { calculateSize } from "./blockstreamApi.js";
+import { Environment } from "@buildwithsygma/core";
 
 dotenv.config();
 
@@ -31,7 +30,6 @@ const {
   ADDRESS,
   AMOUNT,
 } = process.env;
-
 
 if (
   !SOURCE_CAIPID ||
@@ -54,20 +52,21 @@ async function btcToEvmTransfer(): Promise<void> {
   const bip32 = BIP32Factory(tinysecp);
   console.log("Transfer BTC to EVM");
 
-  const { tweakedSigner, publicKeyDropedDERHeader } = await getPublicKey({
+  const { tweakedSigner, publicKeyDropedDERHeader } = (await getPublicKey({
     bip32,
     mnemonic: MNEMONIC as string,
     derivationPath: DERIVATION_PATH as string,
     network: networks.testnet,
-    typeOfAddress: TypeOfAddress.P2TR
-  }
-  ) as { publicKeyDropedDERHeader: Buffer, tweakedSigner: Signer };
+    typeOfAddress: TypeOfAddress.P2TR,
+  })) as { publicKeyDropedDERHeader: Buffer; tweakedSigner: Signer };
 
-  const feeRate = await getFeeEstimates('5');
+  const feeRate = await getFeeEstimates(process.env.SYGMA_ENV, "5");
   const utxos = await fetchUTXOS(
-    ADDRESS as unknown as string);
+    process.env.SYGMA_ENV,
+    ADDRESS as unknown as string
+  );
 
-  const processedUtxos = processUtxos(utxos, AMOUNT);
+  const processedUtxos = processUtxos(utxos, Number(BigInt(AMOUNT!)));
 
   const mapedUtxos = processedUtxos.map((utxo) => ({
     utxoTxId: utxo.txid,
@@ -81,7 +80,7 @@ async function btcToEvmTransfer(): Promise<void> {
     publicKey: publicKeyDropedDERHeader,
     depositAddress: ADDRESS as unknown as string,
     domainId: DESTINATION_CHAIN_ID,
-    amount: AMOUNT,
+    amount: BigInt(AMOUNT!),
     feeValue: BigInt(0),
     changeAddress: ADDRESS as unknown as string,
     signer: tweakedSigner,
@@ -89,11 +88,11 @@ async function btcToEvmTransfer(): Promise<void> {
   });
 
   const transferParams: BitcoinTransferParams = {
-    source: SOURCE_CAIPID,
+    source: SOURCE_CAIPID!,
     destination: DESTINATION_CHAIN_ID,
-    destinationAddress: DESTINATION_ADDRESS,
-    amount: AMOUNT,
-    resource: RESOURCE_ID,
+    destinationAddress: DESTINATION_ADDRESS!,
+    amount: BigInt(AMOUNT!),
+    resource: RESOURCE_ID!,
     utxoData: mapedUtxos,
     feeRate: BigInt(Math.ceil(feeRate)),
     publicKey: publicKeyDropedDERHeader,
@@ -101,6 +100,8 @@ async function btcToEvmTransfer(): Promise<void> {
     network: networks.testnet,
     changeAddress: ADDRESS,
     size: BigInt(size),
+    environment: Environment.TESTNET,
+    sourceAddress: "",
   };
 
   const transfer = await createBitcoinFungibleTransfer(transferParams);
@@ -116,8 +117,8 @@ async function btcToEvmTransfer(): Promise<void> {
   const tx = psbt.extractTransaction(true);
   console.log("Transaction hex", tx.toHex());
 
-  const txId = await broadcastTransaction(tx.toHex());
+  const txId = await broadcastTransaction(process.env.SYGMA_ENV, tx.toHex());
   console.log("Transaction broadcasted", `${EXPLORER_URL}/tx/${txId}`);
 }
 
-btcToEvmTransfer().finally(() => { });
+btcToEvmTransfer().finally(() => {});

--- a/examples/bitcoin-to-evm-fungible-transfer/src/transfer.p2wpkh.ts
+++ b/examples/bitcoin-to-evm-fungible-transfer/src/transfer.p2wpkh.ts
@@ -3,19 +3,17 @@ import {
   createBitcoinFungibleTransfer,
   TypeOfAddress,
   getPublicKey,
-  getFeeEstimates, 
-  fetchUTXOS, 
-  processUtxos, 
-  broadcastTransaction
+  getFeeEstimates,
+  fetchUTXOS,
+  processUtxos,
+  broadcastTransaction,
 } from "@buildwithsygma/bitcoin";
 import { BIP32Factory, BIP32Interface } from "bip32";
 import { initEccLib, networks } from "bitcoinjs-lib";
 import dotenv from "dotenv";
 import * as tinysecp from "tiny-secp256k1";
 
-import {
-  calculateSize,
-} from "./blockstreamApi.js";
+import { calculateSize } from "./blockstreamApi.js";
 
 dotenv.config();
 
@@ -53,19 +51,21 @@ async function btcToEvmTransfer(): Promise<void> {
   const bip32 = BIP32Factory(tinysecp);
   console.log("Transfer BTC to EVM");
 
-  const { derivedNode } = await getPublicKey({
+  const { derivedNode } = (await getPublicKey({
     bip32,
     mnemonic: MNEMONIC as string,
     derivationPath: DERIVATION_PATH as string,
     network: networks.testnet,
-    typeOfAddress: TypeOfAddress.P2WPKH
-  }
-  ) as { derivedNode: BIP32Interface };
+    typeOfAddress: TypeOfAddress.P2WPKH,
+  })) as { derivedNode: BIP32Interface };
 
-  const feeRate = await getFeeEstimates('5');
-  const utxos = await fetchUTXOS(ADDRESS as unknown as string);
+  const feeRate = await getFeeEstimates(process.env.SYGMA_ENV, "5");
+  const utxos = await fetchUTXOS(
+    process.env.SYGMA_ENV,
+    ADDRESS as unknown as string
+  );
 
-  const processedUtxos = processUtxos(utxos, AMOUNT);
+  const processedUtxos = processUtxos(utxos, Number(BigInt(AMOUNT!)));
 
   const mapedUtxos = processedUtxos.map((utxo) => ({
     utxoTxId: utxo.txid,
@@ -79,7 +79,7 @@ async function btcToEvmTransfer(): Promise<void> {
     publicKey: derivedNode.publicKey,
     depositAddress: ADDRESS as unknown as string,
     domainId: DESTINATION_CHAIN_ID,
-    amount: AMOUNT,
+    amount: BigInt(AMOUNT!),
     feeValue: BigInt(0),
     changeAddress: ADDRESS as unknown as string,
     signer: derivedNode,
@@ -87,11 +87,11 @@ async function btcToEvmTransfer(): Promise<void> {
   }); // aprox estimation of the size of the tx
 
   const transferParams: BitcoinTransferParams = {
-    source: SOURCE_CAIPID,
-    destination: DESTINATION_CHAIN_ID,
-    destinationAddress: DESTINATION_ADDRESS,
-    amount: AMOUNT,
-    resource: RESOURCE_ID,
+    source: SOURCE_CAIPID!,
+    destination: DESTINATION_CHAIN_ID!,
+    destinationAddress: DESTINATION_ADDRESS!,
+    amount: BigInt(AMOUNT!),
+    resource: RESOURCE_ID!,
     utxoData: mapedUtxos,
     publicKey: derivedNode.publicKey,
     typeOfAddress: TypeOfAddress.P2WPKH,
@@ -99,6 +99,7 @@ async function btcToEvmTransfer(): Promise<void> {
     changeAddress: ADDRESS,
     feeRate: BigInt(Math.ceil(feeRate)),
     size: BigInt(size),
+    sourceAddress: "",
   };
 
   const transfer = await createBitcoinFungibleTransfer(transferParams);
@@ -114,8 +115,8 @@ async function btcToEvmTransfer(): Promise<void> {
   const tx = psbt.extractTransaction(true);
   console.log("Transaction hex", tx.toHex());
 
-  const txId = await broadcastTransaction(tx.toHex());
+  const txId = await broadcastTransaction(process.env.SYGMA_ENV, tx.toHex());
   console.log("Transaction broadcasted", `${EXPLORER_URL}/tx/${txId}`);
 }
 
-btcToEvmTransfer().finally(() => { });
+btcToEvmTransfer().finally(() => {});

--- a/examples/evm-to-bitcoin-fungible-transfer/src/environment.d.ts
+++ b/examples/evm-to-bitcoin-fungible-transfer/src/environment.d.ts
@@ -1,4 +1,4 @@
-import type { Environment } from '@buildwithsygma/core';
+import type { Environment } from "@buildwithsygma/core";
 
 declare global {
   namespace NodeJS {

--- a/examples/evm-to-bitcoin-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-bitcoin-fungible-transfer/src/transfer.ts
@@ -1,4 +1,8 @@
-import { createEvmFungibleAssetTransfer } from "@buildwithsygma/evm";
+import { Eip1193Provider } from "@buildwithsygma/core";
+import {
+  createFungibleAssetTransfer,
+  FungibleTransferParams,
+} from "@buildwithsygma/evm";
 import dotenv from "dotenv";
 import { Wallet, providers } from "ethers";
 import Web3HttpProvider from "web3-providers-http";
@@ -13,42 +17,54 @@ if (!privateKey) {
 
 const SEPOLIA_CHAIN_ID = 11155111;
 const BITCOIN_DOMAIN_CAIPID = "bip122:000000000933ea01ad0ee984209779ba";
-const RESOURCE_ID = "0x0000000000000000000000000000000000000000000000000000000000000700";
-const SEPOLIA_RPC_URL = process.env.SEPOLIA_RPC_URL || "https://eth-sepolia-public.unifra.io"
+const RESOURCE_ID =
+  "0x0000000000000000000000000000000000000000000000000000000000000700";
+const SEPOLIA_RPC_URL =
+  process.env.SEPOLIA_RPC_URL || "https://eth-sepolia-public.unifra.io";
 const BTC_DESTINATION_ADDRESS = process.env.BTC_DESTINATION_ADDRESS;
 
-const explorerUrls: Record<number, string> = { [SEPOLIA_CHAIN_ID]: 'https://sepolia.etherscan.io' };
-const getTxExplorerUrl = (params: { txHash: string; chainId: number }): string => `${explorerUrls[params.chainId]}/tx/${params.txHash}`;
+const explorerUrls: Record<number, string> = {
+  [SEPOLIA_CHAIN_ID]: "https://sepolia.etherscan.io",
+};
+const getTxExplorerUrl = (params: {
+  txHash: string;
+  chainId: number;
+}): string => `${explorerUrls[params.chainId]}/tx/${params.txHash}`;
 
 export async function erc20Transfer(): Promise<void> {
   const web3Provider = new Web3HttpProvider(SEPOLIA_RPC_URL);
   const ethersWeb3Provider = new providers.Web3Provider(web3Provider);
   const wallet = new Wallet(privateKey!, ethersWeb3Provider);
 
-  const params = {
+  const params: FungibleTransferParams = {
     source: SEPOLIA_CHAIN_ID,
     destination: BITCOIN_DOMAIN_CAIPID,
-    sourceNetworkProvider: web3Provider,
+    sourceNetworkProvider: web3Provider as unknown as Eip1193Provider,
     resource: RESOURCE_ID,
     amount: BigInt(1) * BigInt(1e8), // or any amount to send
-    destinationAddress: BTC_DESTINATION_ADDRESS,
+    recipientAddress: BTC_DESTINATION_ADDRESS!,
     sourceAddress: await wallet.getAddress(),
+    environment: process.env.SYGMA_ENV,
   };
 
-  const transfer = await createEvmFungibleAssetTransfer(params);
+  const transfer = await createFungibleAssetTransfer(params);
 
   const approvals = await transfer.getApprovalTransactions();
   console.log(`Approving Tokens (${approvals.length})...`);
   for (const approval of approvals) {
     const response = await wallet.sendTransaction(approval);
     await response.wait();
-    console.log(`Approved, transaction: ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`);
+    console.log(
+      `Approved, transaction: ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`
+    );
   }
 
   const transferTx = await transfer.getTransferTransaction();
   const response = await wallet.sendTransaction(transferTx);
   await response.wait();
-  console.log(`Deposited, transaction:  ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`);
+  console.log(
+    `Deposited, transaction:  ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`
+  );
 }
 
-erc20Transfer().finally(() => { });
+erc20Transfer().finally(() => {});

--- a/examples/evm-to-evm-erc20-contract-call/src/transfer.ts
+++ b/examples/evm-to-evm-erc20-contract-call/src/transfer.ts
@@ -68,6 +68,7 @@ export async function erc20Transfer(): Promise<void> {
     recipientAddress: ethers.constants.AddressZero,
     sourceAddress: sourceAddress,
     optionalGas: BigInt(5_000_000),
+    environment: process.env.SYGMA_ENV,
     optionalMessage: {
       receiver: destinationAddress,
       transactionId: ethers.utils.formatBytes32String("EVM-ERC20+GENERIC"),

--- a/examples/evm-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-fungible-transfer/src/transfer.ts
@@ -46,6 +46,7 @@ export async function erc20Transfer(): Promise<void> {
     amount: BigInt(1) * BigInt(1e6),
     recipientAddress: destinationAddress,
     sourceAddress: sourceAddress,
+    environment: process.env.SYGMA_ENV,
   };
 
   const transfer = await createFungibleAssetTransfer(params);

--- a/examples/evm-to-evm-generic-message-transfer/src/environment.d.ts
+++ b/examples/evm-to-evm-generic-message-transfer/src/environment.d.ts
@@ -1,4 +1,4 @@
-import type { Environment } from '@buildwithsygma/core';
+import type { Environment } from "@buildwithsygma/core";
 
 declare global {
   namespace NodeJS {

--- a/examples/evm-to-evm-generic-message-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-generic-message-transfer/src/transfer.ts
@@ -81,6 +81,7 @@ export async function genericMessage(): Promise<void> {
     sourceNetworkProvider: sourceProvider as unknown as Eip1193Provider,
     sourceAddress: walletAddress,
     resource: RESOURCE_ID,
+    environment: process.env.SYGMA_ENV,
   });
   // transaction that can be sent to the chain
   const transaction = await transfer.getTransferTransaction();

--- a/examples/evm-to-evm-non-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-evm-non-fungible-transfer/src/transfer.ts
@@ -49,6 +49,7 @@ export async function erc721Transfer(): Promise<void> {
     tokenId: process.env.TOKEN_ID as string,
     recipientAddress: destinationAddress,
     sourceAddress,
+    environment: process.env.SYGMA_ENV,
   };
 
   const transfer = await createNonFungibleAssetTransfer(params);

--- a/examples/evm-to-substrate-fungible-transfer/src/transfer.ts
+++ b/examples/evm-to-substrate-fungible-transfer/src/transfer.ts
@@ -1,5 +1,8 @@
 import type { Eip1193Provider } from "@buildwithsygma/core";
-import { createEvmFungibleAssetTransfer } from "@buildwithsygma/evm";
+import {
+  createFungibleAssetTransfer,
+  FungibleTransferParams,
+} from "@buildwithsygma/evm";
 import dotenv from "dotenv";
 import { Wallet, providers } from "ethers";
 import Web3HttpProvider from "web3-providers-http";
@@ -35,24 +38,25 @@ export async function erc20Transfer(): Promise<void> {
   const sourceAddress = await wallet.getAddress();
   const destinationAddress = "5GjowPEaFNnwbrmpPuDmBVdF2e7n3cHwk2LnUwHXsaW5KtEL";
 
-  const params = {
+  const params: FungibleTransferParams = {
     source: SEPOLIA_CHAIN_ID,
     destination: TANGLE_CHAIN_ID,
     sourceNetworkProvider: web3Provider as unknown as Eip1193Provider,
     resource: RESOURCE_ID,
     amount: BigInt(1) * BigInt(1e18),
-    destinationAddress: destinationAddress,
+    recipientAddress: destinationAddress,
     sourceAddress: sourceAddress,
+    environment: process.env.SYGMA_ENV,
   };
 
-  const transfer = await createEvmFungibleAssetTransfer(params);
+  const transfer = await createFungibleAssetTransfer(params);
   const approvals = await transfer.getApprovalTransactions();
   console.log(`Approving Tokens (${approvals.length})...`);
   for (const approval of approvals) {
     const response = await wallet.sendTransaction(approval);
     await response.wait();
     console.log(
-      `Approved, transaction: ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`,
+      `Approved, transaction: ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`
     );
   }
 
@@ -60,7 +64,7 @@ export async function erc20Transfer(): Promise<void> {
   const response = await wallet.sendTransaction(transferTx);
   await response.wait();
   console.log(
-    `Deposited, transaction:  ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`,
+    `Deposited, transaction:  ${getTxExplorerUrl({ txHash: response.hash, chainId: SEPOLIA_CHAIN_ID })}`
   );
 }
 

--- a/examples/substrate-to-evm-fungible-transfer/src/environment.d.ts
+++ b/examples/substrate-to-evm-fungible-transfer/src/environment.d.ts
@@ -1,4 +1,4 @@
-import type { Environment } from '@buildwithsygma/core';
+import type { Environment } from "@buildwithsygma/core";
 
 declare global {
   namespace NodeJS {

--- a/examples/substrate-to-evm-fungible-transfer/src/transfer.ts
+++ b/examples/substrate-to-evm-fungible-transfer/src/transfer.ts
@@ -44,6 +44,7 @@ const substrateTransfer = async (): Promise<void> => {
     resource: RESOURCE_ID_SYGMA_USD,
     amount: BigInt(1) * BigInt(1e18),
     destinationAddress: recipient,
+    environment: process.env.SYGMA_ENV,
   };
 
   const transfer = await createSubstrateFungibleAssetTransfer(transferParams);
@@ -55,7 +56,7 @@ const substrateTransfer = async (): Promise<void> => {
 
     if (status.isInBlock) {
       console.log(
-        `Transaction included at blockHash ${status.asInBlock.toString()}`,
+        `Transaction included at blockHash ${status.asInBlock.toString()}`
       );
     } else if (status.isFinalized) {
       const blockNumber = results.blockNumber?.toNumber();
@@ -63,10 +64,10 @@ const substrateTransfer = async (): Promise<void> => {
 
       if (blockNumber && extrinsicIndex) {
         console.log(
-          `Transaction finalized at blockHash ${status.asFinalized.toString()}`,
+          `Transaction finalized at blockHash ${status.asFinalized.toString()}`
         );
         console.log(
-          `Explorer URL: ${getSygmaExplorerTransferUrl({ blockNumber, extrinsicIndex })}`,
+          `Explorer URL: ${getSygmaExplorerTransferUrl({ blockNumber, extrinsicIndex })}`
         );
       }
       unsub();

--- a/packages/bitcoin/README.md
+++ b/packages/bitcoin/README.md
@@ -16,8 +16,6 @@ npm install @buildwithsygma/bitcoin
 
 ## Environment Setup
 
-Make sure to set environment variable `SYGMA_ENV` to either `TESTNET` or `MAINNET` prior to using the SDK.
-
 ## Support.
 
 Bridge configuration and list of supported networks for each environment can be found at: [Sygma bridge shared configuration github](https://github.com/sygmaprotocol/sygma-shared-configuration)
@@ -62,14 +60,17 @@ import { createBitcoinFungibleTransfer, TypeOfAddress } from '@buildwithsygma/bi
 import type { BitcoinTransferParams, UTXOData } from '@buildwithsygma/bitcoin';
 import { networks } from 'bitcoinjs-lib';
 import { toXOnly } from 'bitcoinjs-lib/src/psbt/bip371';
+import { Environment } from '@buildwithsygma/core';
 
 // Here we create the public key needed for the P2TR transfer. You can reference our bitcoin-to-evm example to check the steps to get the public key and the signer
 // derivedNode.publicKey is one of your account given the derivation path that you provide
 const publicKeyDropedDERHeader = toXOnly(derivedNode.publicKey);
 
 const transferParams: BitcoinTransferParams = {
+  environment: Environment.TESTNET
   source: 'bip122:000000000933ea01ad0ee984209779ba',
   destination: 11155111,
+  sourceAddress: "<source_wallet_address>",
   destinationAddress: '0x...', // evm address here
   amount: 1e8,
   resource: '0x0000000000000000000000000000000000000000000000000000000000000300',
@@ -99,11 +100,14 @@ console.log('Transaction hex', tx.toHex());
 ```typescript
 import type { BitcoinTransferParams, UTXOData } from '@buildwithsygma/bitcoin';
 import { createBitcoinFungibleTransfer, TypeOfAddress } from '@buildwithsygma/bitcoin';
+import { Environment } from '@buildwithsygma/core';
 import { networks } from 'bitcoinjs-lib';
 
 const derivedNode = rootKey.derivePath('your-derivation-path');
 
 const transferParams: BitcoinTransferParams = {
+  environment: Environment.TESTNET,
+  sourceAddress: '<source_wallet_address>',
   source: 'bip122:000000000933ea01ad0ee984209779ba',
   destination: 11155111,
   destinationAddress: '0x...', // evm address here

--- a/packages/bitcoin/src/fungible.ts
+++ b/packages/bitcoin/src/fungible.ts
@@ -14,7 +14,7 @@ export async function createBitcoinFungibleTransfer(
   params: BitcoinTransferParams,
 ): Promise<BitcoinFungibleTransfer> {
   const config = new Config();
-  await config.init(process.env.SYGMA_ENV || Environment.MAINNET);
+  await config.init(params.environment || Environment.MAINNET);
   return new BitcoinFungibleTransfer(params, config);
 }
 

--- a/packages/bitcoin/src/index.ts
+++ b/packages/bitcoin/src/index.ts
@@ -1,2 +1,3 @@
 export * from './fungible.js';
 export * from './types.js';
+export * from './utils/index.js';

--- a/packages/bitcoin/src/types.ts
+++ b/packages/bitcoin/src/types.ts
@@ -1,4 +1,4 @@
-import type { BaseTransferParams, Environment } from '@buildwithsygma/core';
+import type { BaseTransferParams } from '@buildwithsygma/core';
 import type { BIP32API, BIP32Interface } from 'bip32';
 import type { Network, networks, Psbt, Signer } from 'bitcoinjs-lib';
 

--- a/packages/bitcoin/src/types.ts
+++ b/packages/bitcoin/src/types.ts
@@ -30,7 +30,6 @@ export interface BitcoinTransferParams extends BaseTransferParams {
   feeRate: bigint;
   changeAddress?: string;
   size: bigint;
-  environment?: Environment;
 }
 
 export type CreatePsbtParams = Pick<

--- a/packages/bitcoin/src/types.ts
+++ b/packages/bitcoin/src/types.ts
@@ -1,4 +1,4 @@
-import type { BaseTransferParams } from '@buildwithsygma/core';
+import type { BaseTransferParams, Environment } from '@buildwithsygma/core';
 import type { BIP32API, BIP32Interface } from 'bip32';
 import type { Network, networks, Psbt, Signer } from 'bitcoinjs-lib';
 
@@ -30,6 +30,7 @@ export interface BitcoinTransferParams extends BaseTransferParams {
   feeRate: bigint;
   changeAddress?: string;
   size: bigint;
+  environment?: Environment;
 }
 
 export type CreatePsbtParams = Pick<

--- a/packages/bitcoin/src/utils/blockstream.ts
+++ b/packages/bitcoin/src/utils/blockstream.ts
@@ -5,8 +5,14 @@ const MAINNET_BLOCKSTREAM_URL = 'https://blockstream.info/api';
 
 type FeeEstimates = Record<string, number>;
 
-const blockStreamUrl =
-  process.env.SYGMA_ENV === Environment.MAINNET ? MAINNET_BLOCKSTREAM_URL : TESTNET_BLOCKSTREAM_URL;
+function getBlockStreamUrl(environment: Environment): string {
+  switch (environment) {
+    case Environment.MAINNET:
+      return MAINNET_BLOCKSTREAM_URL;
+    default:
+      return TESTNET_BLOCKSTREAM_URL;
+  }
+}
 
 type Utxo = {
   txid: string;
@@ -26,9 +32,13 @@ type Utxo = {
  * @param blockConfirmations - number of confirmations
  * @returns {Promise<number>} - fee estimate
  */
-export async function getFeeEstimates(blockConfirmations: string): Promise<number> {
+export async function getFeeEstimates(
+  environment: Environment,
+  blockConfirmations: string,
+): Promise<number> {
   try {
-    const response = await fetch(`${blockStreamUrl}/fee-estimates`);
+    const url = getBlockStreamUrl(environment);
+    const response = await fetch(`${url}/fee-estimates`);
 
     const data = (await response.json()) as FeeEstimates;
 
@@ -44,9 +54,13 @@ export async function getFeeEstimates(blockConfirmations: string): Promise<numbe
  * @param txHex - raw hex string of the signed transaction
  * @returns {Promise<string>} - transaction id
  */
-export async function broadcastTransaction(txHex: string): Promise<string> {
+export async function broadcastTransaction(
+  environment: Environment,
+  txHex: string,
+): Promise<string> {
   try {
-    const response = await fetch(`${blockStreamUrl}/tx`, {
+    const url = getBlockStreamUrl(environment);
+    const response = await fetch(`${url}/tx`, {
       method: 'POST',
       body: txHex,
       headers: {
@@ -66,9 +80,10 @@ export async function broadcastTransaction(txHex: string): Promise<string> {
  * @param address - bitcoin address
  * @returns {Promise<Utxo[]>} - array of UTXOs
  */
-export const fetchUTXOS = async (address: string): Promise<Utxo[]> => {
+export const fetchUTXOS = async (environment: Environment, address: string): Promise<Utxo[]> => {
   try {
-    const response = await fetch(`${blockStreamUrl}/address/${address}/utxo`);
+    const url = getBlockStreamUrl(environment);
+    const response = await fetch(`${url}/address/${address}/utxo`);
 
     const data = (await response.json()) as Utxo[];
 

--- a/packages/bitcoin/src/utils/index.ts
+++ b/packages/bitcoin/src/utils/index.ts
@@ -1,1 +1,3 @@
 export * from './helpers.js';
+export * from './blockstream.js';
+export * from './wallet.js';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,8 +14,6 @@ npm install @buildwithsygma/core
 
 ## Environment Setup
 
-Make sure to set environment variable `SYGMA_ENV` to either `TESTNET` or `MAINNET` prior to using the SDK.
-
 ### Usage
 
 #### Config class.

--- a/packages/core/src/baseTransfer.ts
+++ b/packages/core/src/baseTransfer.ts
@@ -1,4 +1,5 @@
 import type { Config } from './config/config.js';
+import { Environment } from './types.js';
 import type {
   Domainlike,
   EvmResource,
@@ -12,6 +13,7 @@ export interface BaseTransferParams {
   destination: Domainlike;
   resource: string | EvmResource | SubstrateResource | BitcoinResource;
   sourceAddress: string;
+  environment?: Environment;
 }
 
 export abstract class BaseTransfer {
@@ -20,6 +22,7 @@ export abstract class BaseTransfer {
   protected transferResource: EvmResource | SubstrateResource | BitcoinResource;
   protected sygmaConfiguration: Config;
   protected sourceAddress: string;
+  protected environment: Environment;
 
   public get source(): Domain {
     return this.sourceDomain;
@@ -52,6 +55,7 @@ export abstract class BaseTransfer {
     this.sourceAddress = transfer.sourceAddress;
     this.sourceDomain = config.getDomain(transfer.source);
     this.destinationDomain = config.getDomain(transfer.destination);
+    this.environment = transfer.environment ?? Environment.MAINNET;
     const resource = this.findResource(transfer.resource);
 
     if (resource) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -24,7 +24,7 @@ import { Environment, Network } from './types.js';
 import { Config } from './index.js';
 
 function getIndexerTransferUrl(
-  env: Environment = process.env.SYGMA_ENV,
+  env: Environment = Environment.MAINNET,
   txHash: string,
 ): {
   explorerUrl: string;
@@ -75,7 +75,7 @@ export function getSygmaScanLink(sourceHash: string, environment: Environment): 
  *
  */
 export async function getEnvironmentMetadata(
-  environment: Environment = process.env.SYGMA_ENV,
+  environment: Environment = Environment.MAINNET,
 ): Promise<EnvironmentMetadata> {
   try {
     const url = `${getIndexerURL(environment)}/api/domains/metadata`;
@@ -125,7 +125,7 @@ export async function getDomains(options: {
  */
 export async function getRoutes(
   source: Domainlike,
-  environment: Environment = process.env.SYGMA_ENV,
+  environment: Environment = Environment.MAINNET,
   options?: {
     routeTypes?: RouteType[];
     sourceProvider?: Eip1193Provider;
@@ -209,7 +209,7 @@ export async function getRoutes(
  */
 export async function getTransferStatus(
   txHash: string,
-  environment: Environment = process.env.SYGMA_ENV,
+  environment: Environment = Environment.MAINNET,
 ): Promise<TransferStatusResponse> {
   const env = environment ?? Environment.MAINNET;
   const { url, explorerUrl } = getIndexerTransferUrl(env, txHash);
@@ -253,7 +253,7 @@ export async function getTransferStatus(
  * @param environment
  */
 export async function getRawConfiguration(
-  environment: Environment = process.env.SYGMA_ENV,
+  environment: Environment = Environment.MAINNET,
 ): Promise<SygmaConfig> {
   const config = new Config();
   await config.init(environment);
@@ -291,11 +291,8 @@ export function isValidEvmAddress(address: string): boolean {
  * @param {string} address
  * @returns {boolean}
  */
-export function isValidBitcoinAddress(address: string): boolean {
-  if (
-    process.env.SYGMA_ENV === Environment.TESTNET ||
-    process.env.SYGMA_ENV === Environment.DEVNET
-  ) {
+export function isValidBitcoinAddress(environment: Environment, address: string): boolean {
+  if (environment === Environment.TESTNET || environment === Environment.DEVNET) {
     return validate(address, BitcoinNetwork.testnet);
   }
 
@@ -308,7 +305,11 @@ export function isValidBitcoinAddress(address: string): boolean {
  * @param {Network} network
  * @returns {boolean}
  */
-export function isValidAddressForNetwork(address: string, network: Network): boolean {
+export function isValidAddressForNetwork(
+  environment: Environment,
+  address: string,
+  network: Network,
+): boolean {
   switch (network) {
     case Network.EVM:
       if (isValidEvmAddress(address)) return true;
@@ -317,7 +318,7 @@ export function isValidAddressForNetwork(address: string, network: Network): boo
       if (isValidSubstrateAddress(address)) return true;
       throw new Error('Invalid Substrate Address');
     case Network.BITCOIN:
-      if (isValidBitcoinAddress(address)) return true;
+      if (isValidBitcoinAddress(environment, address)) return true;
       throw new Error('Invalid Bitcoin Address');
     default:
       throw new Error('Provided network is not supported');

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -120,109 +120,106 @@ describe('Address Validation Utils', () => {
 
   describe('isValidBitcoinAddress', () => {
     describe('For Bitcoin mainnet', () => {
-      beforeEach(() => {
-        process.env.SYGMA_ENV = Environment.MAINNET;
-      });
+      const environment = Environment.MAINNET;
 
       it('should validate a correct P2TR Bitcoin address', () => {
         const p2trAddress = 'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297';
-        expect(isValidBitcoinAddress(p2trAddress)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2trAddress)).toBe(true);
       });
 
       it('should validate a correct P2WPKH Bitcoin address', () => {
         const p2wpkh = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
-        expect(isValidBitcoinAddress(p2wpkh)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2wpkh)).toBe(true);
       });
 
       it('should validate a correct P2SH Bitcoin address', () => {
         const p2sh = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
-        expect(isValidBitcoinAddress(p2sh)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2sh)).toBe(true);
       });
 
       it('should validate a correct P2PKH Bitcoin address', () => {
         const p2sh = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
-        expect(isValidBitcoinAddress(p2sh)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2sh)).toBe(true);
       });
 
       it('should return false for an invalid Bitcoin address', () => {
         const invalidAddress = 'invalidAddress';
-        expect(isValidBitcoinAddress(invalidAddress)).toBe(false);
+        expect(isValidBitcoinAddress(environment, invalidAddress)).toBe(false);
       });
     });
 
     describe('For Bitcoin Testnet', () => {
-      beforeEach(() => {
-        process.env.SYGMA_ENV = Environment.DEVNET;
-      });
+      const environment = Environment.TESTNET;
 
       it('should validate a correct P2WPKH Bitcoin address', () => {
         const p2wpkhAddress = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
-        expect(isValidBitcoinAddress(p2wpkhAddress)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2wpkhAddress)).toBe(true);
       });
 
       it('should validate a correct P2TR Bitcoin address', () => {
         const p2trAddress = 'tb1p84x2ryuyfevgnlpnxt9f39gm7r68gwtvllxqe5w2n5ru00s9aquslzggwq';
-        expect(isValidBitcoinAddress(p2trAddress)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2trAddress)).toBe(true);
       });
 
       it('should validate a correct P2SH Bitcoin address', () => {
         const p2sh = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
-        expect(isValidBitcoinAddress(p2sh)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2sh)).toBe(true);
       });
 
       it('should validate a correct P2PKH Bitcoin address', () => {
         const p2pkh = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn';
-        expect(isValidBitcoinAddress(p2pkh)).toBe(true);
+        expect(isValidBitcoinAddress(environment, p2pkh)).toBe(true);
       });
 
       it('should return false for an invalid Bitcoin address', () => {
         const invalidAddress = 'invalidAddress';
-        expect(isValidBitcoinAddress(invalidAddress)).toBe(false);
+        expect(isValidBitcoinAddress(environment, invalidAddress)).toBe(false);
       });
     });
   });
 
   describe('isValidAddressForNetwork', () => {
+    const environment = Environment.MAINNET;
+
     it('should validate a correct Substrate address for the Substrate network', () => {
       const validAddress = '423DjxJiQJNpULVt4y9Fm6Mcqv63LgANQzxumPg3or855pSY';
-      expect(isValidAddressForNetwork(validAddress, Network.SUBSTRATE)).toBe(true);
+      expect(isValidAddressForNetwork(environment, validAddress, Network.SUBSTRATE)).toBe(true);
     });
 
     it('should validate a correct EVM address for the EVM network', () => {
       const validAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
-      expect(isValidAddressForNetwork(validAddress, Network.EVM)).toBe(true);
+      expect(isValidAddressForNetwork(environment, validAddress, Network.EVM)).toBe(true);
     });
 
     it('should validate a correct Bitcoin address for the Bitcoin network', () => {
-      process.env.SYGMA_ENV = Environment.MAINNET;
       const validAddress = '33TbzA5AMiTKUCmeVEdsnTj3GiVXuavCAH';
-      expect(isValidAddressForNetwork(validAddress, Network.BITCOIN)).toBe(true);
+      expect(isValidAddressForNetwork(environment, validAddress, Network.BITCOIN)).toBe(true);
     });
 
     it('should throw an error for an unsupported network', () => {
       const validAddress = '5F3sa2TJAWMqDhXG6jhV4N8ko9rC2WbCVx2YQ92FsXgnAUx2';
-      expect(() => isValidAddressForNetwork(validAddress, 'unsupportedNetwork' as Network)).toThrow(
-        'Provided network is not supported',
-      );
+      expect(() =>
+        isValidAddressForNetwork(environment, validAddress, 'unsupportedNetwork' as Network),
+      ).toThrow('Provided network is not supported');
     });
 
     it('should throw an error for the wrong EVM address', () => {
       const invalidAddress = 'invalidAddress';
-      expect(() => isValidAddressForNetwork(invalidAddress, Network.EVM)).toThrow(
+      expect(() => isValidAddressForNetwork(environment, invalidAddress, Network.EVM)).toThrow(
         'Invalid EVM Address',
       );
     });
 
     it('should throw an error for the wrong Substrate address', () => {
       const invalidAddress = 'invalidAddress';
-      expect(() => isValidAddressForNetwork(invalidAddress, Network.SUBSTRATE)).toThrow(
-        'Invalid Substrate Address',
-      );
+      expect(() =>
+        isValidAddressForNetwork(environment, invalidAddress, Network.SUBSTRATE),
+      ).toThrow('Invalid Substrate Address');
     });
 
     it('should throw an error for the wrong Bitcoin address', () => {
       const invalidAddress = 'invalidAddress';
-      expect(() => isValidAddressForNetwork(invalidAddress, Network.BITCOIN)).toThrow(
+      expect(() => isValidAddressForNetwork(environment, invalidAddress, Network.BITCOIN)).toThrow(
         'Invalid Bitcoin Address',
       );
     });

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -16,8 +16,6 @@ npm install @buildwithsygma/evm
 
 ## Environment Setup
 
-Make sure to set environment variable `SYGMA_ENV` to either `TESTNET` or `MAINNET` prior to using the SDK.
-
 ## Support.
 
 Bridge configuration and list of supported networks for each environment can be found at: [Sygma bridge shared configuration github](https://github.com/sygmaprotocol/sygma-shared-configuration)
@@ -36,8 +34,9 @@ const transfer = await createFungibleAssetTransfer({
   sourceNetworkProvider: provider,
   resource: '0x0000000000000000000000000000000000000000000000000000000000000200',
   amount: BigInt(2) * BigInt(1e18),
-  destinationAddress: destinationAddress,
+  recipientAddress: "<destination_address>",
   sourceAddress: senderAddress,
+  environment: Environment.TESTNET
 });
 ...
 const approvalTransactions = await transfer.getApprovalTransactions();
@@ -56,8 +55,9 @@ const transfer = await createNonFungibleAssetTransfer({
   sourceNetworkProvider: provider,
   resource: '0x0000000000000000000000000000000000000000000000000000000000000200',
   tokenId: "1",
-  destinationAddress: destinationAddress,
+  recipientAddress: "<destination_address>",
   sourceAddress: senderAddress,
+  environment: Environment.TESTNET
 });
 ...
 const approvalTransactions = await transfer.getApprovalTransactions();
@@ -90,6 +90,7 @@ const transfer = await createCrossChainContractCall<
     sourceNetworkProvider: provider,
     sourceAddress: senderAddress,
     resource: RESOURCE_ID,
+    environment: Environment.TESTNET
 });
 
 const transferTransaction = await transfer.getTransferTransaction();

--- a/packages/evm/src/evmAssetTransfer.ts
+++ b/packages/evm/src/evmAssetTransfer.ts
@@ -88,7 +88,8 @@ export abstract class AssetTransfer extends EvmTransfer implements IAssetTransfe
    * @param {string} address
    */
   public setRecipientAddress(address: string): void {
-    if (isValidAddressForNetwork(address, this.destination.type)) this.recipient = address;
+    if (isValidAddressForNetwork(this.environment, address, this.destination.type))
+      this.recipient = address;
   }
 
   /**

--- a/packages/evm/src/fungibleAssetTransfer.ts
+++ b/packages/evm/src/fungibleAssetTransfer.ts
@@ -1,5 +1,11 @@
 import type { EthereumConfig, EvmResource } from '@buildwithsygma/core';
-import { Config, FeeHandlerType, ResourceType, SecurityModel } from '@buildwithsygma/core';
+import {
+  Config,
+  Environment,
+  FeeHandlerType,
+  ResourceType,
+  SecurityModel,
+} from '@buildwithsygma/core';
 import {
   Bridge__factory,
   ERC20__factory,
@@ -270,7 +276,7 @@ export async function createFungibleAssetTransfer(
   params: FungibleTransferParams,
 ): Promise<FungibleAssetTransfer> {
   const config = new Config();
-  await config.init(process.env.SYGMA_ENV);
+  await config.init(params.environment ?? Environment.MAINNET);
 
   const transfer = new FungibleAssetTransfer(params, config);
 

--- a/packages/evm/src/genericMessageTransfer.ts
+++ b/packages/evm/src/genericMessageTransfer.ts
@@ -1,5 +1,5 @@
 import type { EthereumConfig } from '@buildwithsygma/core';
-import { Config, Network, ResourceType } from '@buildwithsygma/core';
+import { Config, Environment, Network, ResourceType } from '@buildwithsygma/core';
 import { Bridge__factory } from '@buildwithsygma/sygma-contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import type {
@@ -183,7 +183,7 @@ export async function createCrossChainContractCall<
   params: GenericMessageTransferParams<ContractAbi, FunctionName>,
 ): Promise<GenericMessageTransfer<ContractAbi, FunctionName>> {
   const config = new Config();
-  await config.init(process.env.SYGMA_ENV);
+  await config.init(params.environment ?? Environment.MAINNET);
   const genericTransfer = new GenericMessageTransfer<ContractAbi, FunctionName>(params, config);
 
   const isValidTransfer = await genericTransfer.isValidTransfer();

--- a/packages/evm/src/nonFungibleAssetTransfer.ts
+++ b/packages/evm/src/nonFungibleAssetTransfer.ts
@@ -1,5 +1,5 @@
 import type { EvmResource } from '@buildwithsygma/core';
-import { Config, ResourceType } from '@buildwithsygma/core';
+import { Config, Environment, ResourceType } from '@buildwithsygma/core';
 import {
   Bridge__factory,
   ERC721MinterBurnerPauser__factory,
@@ -93,7 +93,7 @@ export async function createNonFungibleAssetTransfer(
   params: NonFungibleTransferParams,
 ): Promise<NonFungibleAssetTransfer> {
   const config = new Config();
-  await config.init(process.env.SYGMA_ENV);
+  await config.init(params.environment ?? Environment.MAINNET);
 
   const transfer = new NonFungibleAssetTransfer(params, config);
 

--- a/packages/substrate/README.md
+++ b/packages/substrate/README.md
@@ -16,8 +16,6 @@ npm install @buildwithsygma/substrate
 
 ## Environment Setup.
 
-Make sure to set environment variable `SYGMA_ENV` to either `TESTNET` or `MAINNET` prior to using the SDK.
-
 ## Support
 
 Bridge configuration and list of supported networks for each environment can be found at: [Sygma bridge shared configuration github](https://github.com/sygmaprotocol/sygma-shared-configuration)
@@ -28,6 +26,7 @@ Bridge configuration and list of supported networks for each environment can be 
 
 ```typescript
 import { createSubstrateFungibleAssetTransfer } from '@buildwithsygma/substrate';
+import { Environment } from '@buildwithsygma/core';
 ...
 const transferParams = {
   sourceDomain: 5231,
@@ -36,6 +35,7 @@ const transferParams = {
   resource: '0x0000000000000000000000000000000000000000000000000000000000001100',
   amount: BigInt('5000000'),
   destinationAddress: recipientAddress,
+  environment: Environment.TESTNET
 };
 ...
 const transfer = await createSubstrateFungibleAssetTransfer(transferParams);

--- a/packages/substrate/src/__test__/fungible.test.ts
+++ b/packages/substrate/src/__test__/fungible.test.ts
@@ -1,4 +1,4 @@
-import { FeeHandlerType } from '@buildwithsygma/core';
+import { Environment, FeeHandlerType } from '@buildwithsygma/core';
 import type { SubmittableResult } from '@polkadot/api';
 import { ApiPromise } from '@polkadot/api';
 import type { SubmittableExtrinsic } from '@polkadot/api-base/types';
@@ -31,6 +31,7 @@ describe('SubstrateFungibleAssetTransfer', () => {
       resource: '0x0000000000000000000000000000000000000000000000000000000000000300',
       amount: BigInt(100),
       destinationAddress: '0x98729c03c4D5e820F5e8c45558ae07aE63F97461',
+      environment: Environment.LOCAL,
     };
   });
 

--- a/packages/substrate/src/__test__/utils/deposit/deposit.test.ts
+++ b/packages/substrate/src/__test__/utils/deposit/deposit.test.ts
@@ -9,7 +9,8 @@ describe('createDestIdMultilocationData', () => {
   it('should create multilocation data for LOCAL environment', () => {
     const address = '0x123abc';
     const domainId = '42';
-    const data = createDestIdMultilocationData(address, domainId);
+    const environment = Environment.LOCAL;
+    const data = createDestIdMultilocationData(environment, address, domainId);
 
     expect(data).toEqual({
       parents: 0,
@@ -23,10 +24,10 @@ describe('createDestIdMultilocationData', () => {
   });
 
   it('should create multilocation data for non-LOCAL environment', () => {
-    process.env.SYGMA_ENV = Environment.DEVNET;
+    const environment = Environment.DEVNET;
     const address = '0x123abc';
     const domainId = '42';
-    const data = createDestIdMultilocationData(address, domainId);
+    const data = createDestIdMultilocationData(environment, address, domainId);
 
     expect(data).toEqual({
       parents: 0,
@@ -43,7 +44,6 @@ describe('createDestIdMultilocationData', () => {
 
 describe('deposit', () => {
   it('should create a deposit transaction', () => {
-    process.env.SYGMA_ENV = Environment.LOCAL;
     const xcmMultiAssetId: XcmMultiAssetIdType = {
       concrete: {
         parents: 1,
@@ -68,7 +68,14 @@ describe('deposit', () => {
       },
     } as unknown as ApiPromise;
 
-    deposit(mockApi, xcmMultiAssetId, amount, destinationDomainId, destinationAddress);
+    deposit(
+      Environment.LOCAL,
+      mockApi,
+      xcmMultiAssetId,
+      amount,
+      destinationDomainId,
+      destinationAddress,
+    );
 
     expect(mockApi.tx.sygmaBridge.deposit).toHaveBeenCalledWith(
       {

--- a/packages/substrate/src/utils/deposit/deposit.ts
+++ b/packages/substrate/src/utils/deposit/deposit.ts
@@ -11,9 +11,11 @@ import { numberToHex } from '@polkadot/util';
  * @param {string} domainId - The domain identifier.
  * @returns {object} - The destination multilocation object.
  */
-export const createDestIdMultilocationData = (address: string, domainId: string): object => {
-  const environment = process.env.SYGMA_ENV;
-
+export const createDestIdMultilocationData = (
+  environment: Environment,
+  address: string,
+  domainId: string,
+): object => {
   switch (environment) {
     case Environment.LOCAL:
       return {
@@ -79,6 +81,7 @@ export const createMultiAssetData = (
  * @returns {SubmittableExtrinsic<"promise", SubmittableResult>} - A SubmittableExtrinsic representing the deposit transaction.
  */
 export const deposit = (
+  environment: Environment,
   api: ApiPromise,
   xcmMultiAssetId: XcmMultiAssetIdType,
   amount: string,
@@ -87,6 +90,7 @@ export const deposit = (
 ): SubmittableExtrinsic<'promise', SubmittableResult> => {
   const asset = createMultiAssetData(xcmMultiAssetId, amount);
   const destIdMultilocation = createDestIdMultilocationData(
+    environment,
     destinationAddress,
     destinationDomainId,
   );

--- a/packages/utils/src/environment.d.ts
+++ b/packages/utils/src/environment.d.ts
@@ -1,9 +1,0 @@
-import type { Environment } from '@buildwithsygma/core';
-
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv {
-      SYGMA_ENV: Environment;
-    }
-  }
-}


### PR DESCRIPTION
Fix: remove `process` depedency which causes browser integration failure

- Fixed all examples
- Removed `env` dependancy
- Fixed tests

## Description
Removal of environment variable from process object, this is needed for browser environment as `process` is a node based object

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have ensured that all acceptance criteria (or expected behavior) from issue are met